### PR TITLE
Enable noImplicitOverride and add explicit override modifiers

### DIFF
--- a/.changeset/enforce-no-implicit-override.md
+++ b/.changeset/enforce-no-implicit-override.md
@@ -10,9 +10,20 @@ across 39 files. This is a non-behavioral, compile-time-only change: no runtime
 logic, method signatures, or data fields are affected, and the full test suite
 is unchanged and green.
 
+The members affected span methods, getter/setter accessors, and properties.
+Constructors, `private`/`#private` members, and interface implementations are
+intentionally untouched — `noImplicitOverride` only governs `extends`-based
+inheritance.
+
 **Why:** explicit `override` makes inheritance intent visible and safe. Renaming
 or removing a base-class member now produces a compile error at every stale
 override (rather than silently leaving a new, disconnected member behind), and
 overrides that no longer match a base member are caught immediately. With the
 flag enabled, the compiler enforces the keyword on all future overrides, so the
 codebase stays consistent without manual review.
+
+**Scope:** the keyword is applied wherever the compiler can prove a base member
+exists. Members that override loosely-typed Foundry base classes (via
+`fvtt-types/lenient`) or classes produced by the sheet mixins may not all be
+marked, because the base member isn't visible to the type checker; this is
+expected and harmless.

--- a/.changeset/enforce-no-implicit-override.md
+++ b/.changeset/enforce-no-implicit-override.md
@@ -1,0 +1,18 @@
+---
+"sohl": patch
+---
+
+Enforce explicit `override` modifiers with `noImplicitOverride`
+
+Enable the TypeScript `noImplicitOverride` compiler option and add the `override`
+keyword to every class member that overrides a base-class member — 67 members
+across 39 files. This is a non-behavioral, compile-time-only change: no runtime
+logic, method signatures, or data fields are affected, and the full test suite
+is unchanged and green.
+
+**Why:** explicit `override` makes inheritance intent visible and safe. Renaming
+or removing a base-class member now produces a compile error at every stale
+override (rather than silently leaving a new, disconnected member behind), and
+overrides that no longer match a base member are caught immediately. With the
+flag enabled, the compiler enforces the keyword on all future overrides, so the
+codebase stays consistent without manual review.

--- a/src/core/SohlDataModel.ts
+++ b/src/core/SohlDataModel.ts
@@ -228,7 +228,7 @@ export namespace SohlDataModel {
         TBase extends foundry.applications.api.DocumentSheetV2.AnyConstructor,
     >(Base: TBase): TBase {
         return class SMix extends HandlebarsApplicationMixin(Base) {
-            static DEFAULT_OPTIONS: PlainObject = {
+            static override DEFAULT_OPTIONS: PlainObject = {
                 classes: ["sohl"],
             };
             _dragDrop: DragDrop[];
@@ -245,7 +245,7 @@ export namespace SohlDataModel {
                 return super.document as TDocument;
             }
 
-            _configureRenderOptions(
+            override _configureRenderOptions(
                 options: Partial<foundry.applications.api.HandlebarsApplicationMixin.RenderOptions>,
             ): void {
                 super._configureRenderOptions(options);

--- a/src/document/actor/foundry/AssemblyDataModel.ts
+++ b/src/document/actor/foundry/AssemblyDataModel.ts
@@ -44,7 +44,7 @@ export class AssemblyDataModel<
     ];
     static override readonly kind = ACTOR_KIND.ASSEMBLY;
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineAssemblyDataSchema();
     }
 }

--- a/src/document/actor/foundry/AssemblySheet.ts
+++ b/src/document/actor/foundry/AssemblySheet.ts
@@ -15,7 +15,7 @@ import { SohlActorSheetBase } from "@src/document/actor/foundry/SohlActor";
 import type { AssemblyLogic } from "@src/document/actor/logic/AssemblyLogic";
 
 export class AssemblySheet extends SohlActorSheetBase {
-    static DEFAULT_OPTIONS: PlainObject = {
+    static override DEFAULT_OPTIONS: PlainObject = {
         id: "assembly-sheet",
         tag: "form",
         position: { width: 900, height: 640 },
@@ -46,7 +46,7 @@ export class AssemblySheet extends SohlActorSheetBase {
         },
     } as const;
 
-    static TABS = {
+    static override TABS = {
         primary: {
             initial: "facade",
             tabs: [

--- a/src/document/actor/foundry/BeingDataModel.ts
+++ b/src/document/actor/foundry/BeingDataModel.ts
@@ -40,7 +40,7 @@ export class BeingDataModel<
     ];
     static override readonly kind = ACTOR_KIND.BEING;
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineBeingDataSchema();
     }
 }

--- a/src/document/actor/foundry/BeingSheet.ts
+++ b/src/document/actor/foundry/BeingSheet.ts
@@ -90,7 +90,7 @@ export class BeingSheet extends SohlActorSheetBase {
         },
     } as const;
 
-    static TABS = {
+    static override TABS = {
         primary: {
             initial: "facade",
             tabs: [
@@ -217,7 +217,7 @@ export class BeingSheet extends SohlActorSheetBase {
         }),
     ];
 
-    async _onRender(
+    override async _onRender(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlActor>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<void> {
@@ -360,7 +360,7 @@ export class BeingSheet extends SohlActorSheetBase {
     /*  Part Context Dispatcher                     */
     /* -------------------------------------------- */
 
-    async _preparePartContext(
+    override async _preparePartContext(
         partId: string,
         context: RenderContext,
         options: RenderOptions,
@@ -460,7 +460,7 @@ export class BeingSheet extends SohlActorSheetBase {
     /* -------------------------------------------- */
 
     /** Prepare context for the sheet header: name, image, health, status effects, body parts. */
-    async _prepareHeaderContext(
+    override async _prepareHeaderContext(
         context: RenderContext,
         _options: RenderOptions,
     ): Promise<RenderContext> {
@@ -491,7 +491,7 @@ export class BeingSheet extends SohlActorSheetBase {
     }
 
     /** Prepare context for the Tabs navigation. */
-    async _prepareTabsContext(
+    override async _prepareTabsContext(
         context: RenderContext,
         _options: RenderOptions,
     ): Promise<RenderContext> {
@@ -499,7 +499,7 @@ export class BeingSheet extends SohlActorSheetBase {
     }
 
     /** Prepare context for the Facade tab: bio image and description. */
-    async _prepareFacadeContext(
+    override async _prepareFacadeContext(
         context: RenderContext,
         _options: RenderOptions,
     ): Promise<RenderContext> {

--- a/src/document/actor/foundry/CohortDataModel.ts
+++ b/src/document/actor/foundry/CohortDataModel.ts
@@ -71,7 +71,7 @@ export class CohortDataModel<
     moveRepName!: string;
     members!: { shortcode: string; name: string; role: string }[];
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineCohortDataSchema();
     }
 

--- a/src/document/actor/foundry/CohortSheet.ts
+++ b/src/document/actor/foundry/CohortSheet.ts
@@ -14,7 +14,7 @@
 import { SohlActorSheetBase } from "@src/document/actor/foundry/SohlActor";
 
 export class CohortSheet extends SohlActorSheetBase {
-    static DEFAULT_OPTIONS: PlainObject = {
+    static override DEFAULT_OPTIONS: PlainObject = {
         id: "cohort-sheet",
         tag: "form",
         position: { width: 900, height: 640 },
@@ -33,7 +33,7 @@ export class CohortSheet extends SohlActorSheetBase {
         effects: { template: "systems/sohl/templates/actor/parts/effects.hbs" },
     } as const;
 
-    static TABS = {
+    static override TABS = {
         primary: {
             initial: "facade",
             tabs: [

--- a/src/document/actor/foundry/SohlActor.ts
+++ b/src/document/actor/foundry/SohlActor.ts
@@ -354,7 +354,7 @@ export class SohlActor extends Actor {
      */
     setupIntrinsicActions(context: SohlActionContext): void {}
 
-    prepareBaseData(): void {
+    override prepareBaseData(): void {
         super.prepareBaseData();
         this._speaker = undefined;
         this._lifecycleActionsCache = new Map<string, SohlItem>();
@@ -460,7 +460,7 @@ export class SohlActor extends Actor {
         });
     }
 
-    prepareDerivedData(): void {
+    override prepareDerivedData(): void {
         super.prepareDerivedData();
         const ctx = this._getContext();
         if (
@@ -517,7 +517,7 @@ export class SohlActor extends Actor {
     //     // Function body here
     // }
 
-    async _preCreate(
+    override async _preCreate(
         createData: PlainObject,
         options: PlainObject,
         user: User,
@@ -588,7 +588,7 @@ export class SohlActor extends Actor {
      * @param user - The user attempting the update.
      * @returns `false` to cancel the update, otherwise delegates to super.
      */
-    async _preUpdate(
+    override async _preUpdate(
         changes: PlainObject,
         options: PlainObject,
         user: User,
@@ -621,7 +621,7 @@ export class SohlActor extends Actor {
         }
     }
 
-    _onCreate(data: PlainObject, options: any, userId: string) {
+    override _onCreate(data: PlainObject, options: any, userId: string) {
         // Call base implementation dynamically to avoid TypeScript override signature noise
         const __sohl_base = Object.getPrototypeOf(SohlActor.prototype) as any;
         __sohl_base._onCreate.call(
@@ -758,7 +758,7 @@ const SohlActorSheetBase_Base = SohlDataModel.SheetMixin<
 >(foundry.applications.api.DocumentSheetV2<SohlActor>);
 
 export abstract class SohlActorSheetBase extends SohlActorSheetBase_Base {
-    get document(): SohlActor {
+    override get document(): SohlActor {
         return super.document as SohlActor;
     }
 
@@ -766,7 +766,7 @@ export abstract class SohlActorSheetBase extends SohlActorSheetBase_Base {
         return (this.document as any).actor;
     }
 
-    _configureRenderOptions(
+    override _configureRenderOptions(
         options: Partial<foundry.applications.api.HandlebarsApplicationMixin.RenderOptions>,
     ): void {
         super._configureRenderOptions(options);
@@ -775,7 +775,7 @@ export abstract class SohlActorSheetBase extends SohlActorSheetBase_Base {
         options.parts = ["header", "tabs", "facade"];
     }
 
-    async _prepareContext(
+    override async _prepareContext(
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<
         foundry.applications.api.DocumentSheetV2.RenderContext<SohlActor>

--- a/src/document/actor/foundry/StructureDataModel.ts
+++ b/src/document/actor/foundry/StructureDataModel.ts
@@ -45,7 +45,7 @@ export class StructureDataModel<
     ];
     static override readonly kind = ACTOR_KIND.STRUCTURE;
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineStructureDataSchema();
     }
 }

--- a/src/document/actor/foundry/StructureSheet.ts
+++ b/src/document/actor/foundry/StructureSheet.ts
@@ -14,7 +14,7 @@
 import { SohlActorSheetBase } from "@src/document/actor/foundry/SohlActor";
 
 export class StructureSheet extends SohlActorSheetBase {
-    static DEFAULT_OPTIONS: PlainObject = {
+    static override DEFAULT_OPTIONS: PlainObject = {
         id: "structure-sheet",
         tag: "form",
         position: { width: 900, height: 640 },
@@ -33,7 +33,7 @@ export class StructureSheet extends SohlActorSheetBase {
         effects: { template: "systems/sohl/templates/actor/parts/effects.hbs" },
     } as const;
 
-    static TABS = {
+    static override TABS = {
         primary: {
             initial: "facade",
             tabs: [

--- a/src/document/actor/foundry/VehicleDataModel.ts
+++ b/src/document/actor/foundry/VehicleDataModel.ts
@@ -100,7 +100,7 @@ export class VehicleDataModel<
     static override readonly kind = ACTOR_KIND.VEHICLE;
     occupants!: string[];
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineVehicleDataSchema();
     }
 }

--- a/src/document/actor/foundry/VehicleSheet.ts
+++ b/src/document/actor/foundry/VehicleSheet.ts
@@ -14,7 +14,7 @@
 import { SohlActorSheetBase } from "@src/document/actor/foundry/SohlActor";
 
 export class VehicleSheet extends SohlActorSheetBase {
-    static DEFAULT_OPTIONS: PlainObject = {
+    static override DEFAULT_OPTIONS: PlainObject = {
         id: "vehicle-sheet",
         tag: "form",
         position: { width: 900, height: 640 },
@@ -31,7 +31,7 @@ export class VehicleSheet extends SohlActorSheetBase {
         effects: { template: "systems/sohl/templates/actor/parts/effects.hbs" },
     } as const;
 
-    static TABS = {
+    static override TABS = {
         primary: {
             initial: "facade",
             tabs: [

--- a/src/document/combatant/SohlCombatant.ts
+++ b/src/document/combatant/SohlCombatant.ts
@@ -40,7 +40,7 @@ export interface StrikeModeRef {
 export class SohlCombatant<
     SubType extends Combatant.SubType = Combatant.SubType,
 > extends Combatant<SubType> {
-    get actor(): SohlActor | null {
+    override get actor(): SohlActor | null {
         return super.actor as SohlActor | null;
     }
 

--- a/src/document/effect/SohlActiveEffect.ts
+++ b/src/document/effect/SohlActiveEffect.ts
@@ -383,14 +383,14 @@ export class SohlActiveEffectDataModel<
         strikeModePredicate?: string;
     }>;
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineActiveEffectDataSchema();
     }
 }
 
 const BaseAEConfig = foundry.applications.sheets.ActiveEffectConfig;
 export class SohlActiveEffectSheet extends BaseAEConfig {
-    static PARTS = {
+    static override PARTS = {
         header: { template: "templates/sheets/active-effect/header.hbs" },
         tabs: { template: "templates/generic/tab-navigation.hbs" },
         details: {
@@ -406,7 +406,7 @@ export class SohlActiveEffectSheet extends BaseAEConfig {
     };
 
     /** @inheritDoc */
-    async _preparePartContext(
+    override async _preparePartContext(
         partId: string,
         context: PlainObject,
     ): Promise<foundry.applications.api.ApplicationV2.RenderContextOf<this>> {

--- a/src/document/item/foundry/AffiliationSheet.ts
+++ b/src/document/item/foundry/AffiliationSheet.ts
@@ -26,7 +26,7 @@ export class AffiliationSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/AfflictionSheet.ts
+++ b/src/document/item/foundry/AfflictionSheet.ts
@@ -26,7 +26,7 @@ export class AfflictionSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/ArmorGearSheet.ts
+++ b/src/document/item/foundry/ArmorGearSheet.ts
@@ -26,7 +26,7 @@ export class ArmorGearSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/AttributeSheet.ts
+++ b/src/document/item/foundry/AttributeSheet.ts
@@ -26,7 +26,7 @@ export class TraitSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/CombatTechniqueSheet.ts
+++ b/src/document/item/foundry/CombatTechniqueSheet.ts
@@ -27,7 +27,7 @@ export class CombatTechniqueSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/ConcoctionGearSheet.ts
+++ b/src/document/item/foundry/ConcoctionGearSheet.ts
@@ -26,7 +26,7 @@ export class ConcoctionGearSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/ContainerGearSheet.ts
+++ b/src/document/item/foundry/ContainerGearSheet.ts
@@ -26,7 +26,7 @@ export class ContainerGearSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/LineageSheet.ts
+++ b/src/document/item/foundry/LineageSheet.ts
@@ -27,7 +27,7 @@ export class LineageSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/MiscGearSheet.ts
+++ b/src/document/item/foundry/MiscGearSheet.ts
@@ -26,7 +26,7 @@ export class MiscGearSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/MysterySheet.ts
+++ b/src/document/item/foundry/MysterySheet.ts
@@ -26,7 +26,7 @@ export class MysterySheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/MysticalAbilitySheet.ts
+++ b/src/document/item/foundry/MysticalAbilitySheet.ts
@@ -27,7 +27,7 @@ export class MysticalAbilitySheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/ProjectileGearDataModel.ts
+++ b/src/document/item/foundry/ProjectileGearDataModel.ts
@@ -90,7 +90,7 @@ export class ProjectileGearDataModel<
         aspect: ImpactAspect;
     };
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineProjectileGearSchema();
     }
 }

--- a/src/document/item/foundry/ProjectileGearSheet.ts
+++ b/src/document/item/foundry/ProjectileGearSheet.ts
@@ -26,7 +26,7 @@ export class ProjectileGearSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/SkillSheet.ts
+++ b/src/document/item/foundry/SkillSheet.ts
@@ -27,7 +27,7 @@ export class SkillSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/SohlItem.ts
+++ b/src/document/item/foundry/SohlItem.ts
@@ -71,7 +71,7 @@ export class SohlItem extends Item {
      * @param user - The user attempting the update.
      * @returns `false` to cancel the update, otherwise delegates to super.
      */
-    async _preUpdate(
+    override async _preUpdate(
         changes: PlainObject,
         options: PlainObject,
         user: User,
@@ -266,7 +266,7 @@ export class SohlItem extends Item {
     /**
      * The SohlActor that owns this item, or null if it is unowned.
      */
-    get actor(): SohlActor | null {
+    override get actor(): SohlActor | null {
         return this.parent;
     }
 }
@@ -421,7 +421,7 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
         },
     };
 
-    static TABS = {
+    static override TABS = {
         sheet: {
             navSelector: ".tabs[data-group='sheet']",
             contentSelector: ".content[data-group='sheet']",
@@ -439,7 +439,7 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
         },
     };
 
-    get document(): SohlItem {
+    override get document(): SohlItem {
         return super.document as SohlItem;
     }
 
@@ -451,7 +451,7 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
         return this.item.actor;
     }
 
-    _configureRenderOptions(
+    override _configureRenderOptions(
         options: Partial<foundry.applications.api.HandlebarsApplicationMixin.RenderOptions>,
     ): void {
         super._configureRenderOptions(options);
@@ -464,7 +464,7 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
         options.parts.push("properties", "description", "actions", "effects");
     }
 
-    async _prepareContext(options: RenderOptions): Promise<RenderContext> {
+    override async _prepareContext(options: RenderOptions): Promise<RenderContext> {
         const context = await super._prepareContext(options);
 
         // Add any shared data needed across all parts here

--- a/src/document/item/foundry/TraitSheet.ts
+++ b/src/document/item/foundry/TraitSheet.ts
@@ -26,7 +26,7 @@ export class TraitSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/TraumaSheet.ts
+++ b/src/document/item/foundry/TraumaSheet.ts
@@ -26,7 +26,7 @@ export class TraumaSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/foundry/WeaponGearDataModel.ts
+++ b/src/document/item/foundry/WeaponGearDataModel.ts
@@ -53,7 +53,7 @@ export class WeaponGearDataModel<
         return this.strikeModes;
     }
 
-    static defineSchema(): foundry.data.fields.DataSchema {
+    static override defineSchema(): foundry.data.fields.DataSchema {
         return defineWeaponGearSchema();
     }
 }

--- a/src/document/item/foundry/WeaponGearSheet.ts
+++ b/src/document/item/foundry/WeaponGearSheet.ts
@@ -26,7 +26,7 @@ export class WeaponGearSheet extends SohlItemSheetBase {
         },
     };
 
-    protected async _preparePropertiesContext(
+    protected override async _preparePropertiesContext(
         context: foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>,
         options: foundry.applications.api.DocumentSheetV2.RenderOptions,
     ): Promise<

--- a/src/document/item/logic/MysticalAbilityLogic.ts
+++ b/src/document/item/logic/MysticalAbilityLogic.ts
@@ -68,7 +68,7 @@ export class MysticalAbilityLogic<
     /* --------------------------------------------- */
 
     /** @inheritdoc */
-    initialize(): void {
+    override initialize(): void {
         super.initialize();
         this.charges = {
             value: new ValueModifier({}, { parent: this }).setBase(
@@ -108,7 +108,7 @@ export class MysticalAbilityLogic<
     }
 
     /** @inheritdoc */
-    evaluate(): void {
+    override evaluate(): void {
         super.evaluate();
 
         if (!this.actor) return;
@@ -124,7 +124,7 @@ export class MysticalAbilityLogic<
     }
 
     /** @inheritdoc */
-    finalize(): void {
+    override finalize(): void {
         super.finalize();
 
         // Now, if we have an associated skill, merge that skill's mastery level into this ability's mastery level.

--- a/src/domain/modifier/ImpactModifier.ts
+++ b/src/domain/modifier/ImpactModifier.ts
@@ -73,7 +73,7 @@ export class ImpactModifier extends ValueModifier {
             isImpactAspect(data.aspect) ? data.aspect : IMPACT_ASPECT.BLUNT;
     }
     // Getter for disabled
-    get disabled(): string {
+    override get disabled(): string {
         return (
             super.disabled ||
             (this.die === 0 && this.effective === 0 ?

--- a/src/domain/result/AttackResult.ts
+++ b/src/domain/result/AttackResult.ts
@@ -57,7 +57,7 @@ export class AttackResult extends SuccessTestResult {
         this.spread = data.spread ?? 0;
     }
 
-    async evaluate(): Promise<boolean> {
+    override async evaluate(): Promise<boolean> {
         const allowed = await super.evaluate();
         if (!allowed) return false;
 
@@ -90,7 +90,7 @@ export class AttackResult extends SuccessTestResult {
         return true;
     }
 
-    async testDialog(
+    override async testDialog(
         data: PlainObject = {},
         callback: (formData: StrictObject<string | number>) => void,
     ): Promise<any> {
@@ -121,7 +121,7 @@ export class AttackResult extends SuccessTestResult {
         );
     }
 
-    async toChat(data = {}) {
+    override async toChat(data = {}) {
         return super.toChat({
             ...data,
             impact: this.impact,

--- a/src/domain/result/DefendResult.ts
+++ b/src/domain/result/DefendResult.ts
@@ -43,7 +43,7 @@ export class DefendResult extends SuccessTestResult {
         );
     }
 
-    async evaluate(): Promise<boolean> {
+    override async evaluate(): Promise<boolean> {
         const allowed = await super.evaluate();
         if (!allowed) return false;
 

--- a/src/domain/result/OpposedTestResult.ts
+++ b/src/domain/result/OpposedTestResult.ts
@@ -141,7 +141,7 @@ export class OpposedTestResult extends TestResult {
         return result;
     }
 
-    async evaluate(): Promise<boolean> {
+    override async evaluate(): Promise<boolean> {
         if (this.sourceTestResult && this.targetTestResult) {
             let allowed = await super.evaluate();
             allowed &&= !!(await this.sourceTestResult.evaluate());

--- a/src/domain/result/SuccessTestResult.ts
+++ b/src/domain/result/SuccessTestResult.ts
@@ -327,7 +327,7 @@ export class SuccessTestResult extends TestResult {
         });
     }
 
-    async evaluate() {
+    override async evaluate() {
         let allowed = await super.evaluate();
         if (allowed === false) return false;
         if (!this._speaker.isOwner) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "declaration": true,
         "outDir": "./build/generated",
         "strict": true,
+        "noImplicitOverride": true,
         "noEmitOnError": true,
         "types": ["fvtt-types/lenient", "vitest/globals"],
         "paths": {


### PR DESCRIPTION
Enables the TypeScript noImplicitOverride option and adds the override keyword to every member that overrides a base-class member: 67 members across 39 files (methods, getter/setter accessors, and properties). Applied mechanically via the TypeScript language-service code fix for TS4114. Non-behavioral change: build:types compiles clean with the flag on and the full test suite passes unchanged. The flag stays on so future overrides must be marked. See the changeset for scope notes on loosely-typed Foundry and mixin overrides.