### PR TITLE
fix(ui): constrain actor sheet header portrait

### DIFF
--- a/.changeset/fix-actor-header-portrait-size.md
+++ b/.changeset/fix-actor-header-portrait-size.md
@@ -1,0 +1,11 @@
+---
+"sohl": patch
+---
+
+**Constrain the actor sheet header portrait**
+
+Fixes [#57](https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/issues/57):
+the header portrait sizing rule now targets `img.actor-img` — the class the actor
+header templates actually render — instead of the stale `img.profile` selector.
+The portrait is held to 100px again on all five actor sheets, so the header is
+compact and the tab content area gets its space back.

--- a/scss/components/_top.scss
+++ b/scss/components/_top.scss
@@ -164,7 +164,7 @@ label.init-checkbox {
             }
         }
 
-        img.profile {
+        img.actor-img {
             flex: 0 0 100px;
             max-width: 100px;
             height: 100px;


### PR DESCRIPTION
## Summary

Fixes the over-large header portrait that squeezed the tab content area on every
actor sheet.

The actor headers render `<img class="actor-img">`, and Foundry's core
`.flexrow > *` rule gives each flex child `flex: 1`. The SoHL rule meant to cap
the portrait targeted a stale class (`img.profile`) that no template uses, so the
override never applied and the portrait expanded to fill half the row at unbounded
height. The selector is renamed to `img.actor-img`, restoring the intended 100px
portrait across all five actor sheets (Being, Cohort, Structure, Vehicle,
Assembly).

Fixes #57.

## Testing

- `npm run build:css` — compiles clean; the rule now emits as
  `.sohl .sheet .sheet-header img.actor-img`.

Manual: `npm run push:qa`, reload, open an actor sheet — the header is compact and
the tab content area fills the remaining space.
