### PR TITLE
fix(packs): write _key on embedded items in actor export

### DIFF
--- a/.changeset/fix-actor-pack-embedded-item-keys.md
+++ b/.changeset/fix-actor-pack-embedded-item-keys.md
@@ -1,0 +1,13 @@
+---
+"sohl": patch
+---
+
+**Key embedded items when exporting the actors pack**
+
+Fixes [#59](https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/issues/59):
+the actor pack exporter now writes a hierarchical `_key`
+(`!actors.items!<actorId>.<itemId>`, and `!actors.items.effects!…` for any
+effects an item carries) on each embedded item. Foundry's LevelDB pack compiler
+keys every embedded document by `_key`, so without it the compile aborted with
+`LEVEL_INVALID_KEY` ("Key cannot be null or undefined") as soon as the actors
+pack contained an actor.

--- a/utils/packs/actors.mjs
+++ b/utils/packs/actors.mjs
@@ -241,6 +241,18 @@ export class Actors {
         const merged = overlay ? deepMerge(base, overlay) : base;
         merged.type = type;
         merged._id = makeId(actorId, `${type}:${shortcode || merged.name}:${indexKey}`);
+        // Foundry's pack compiler flattens the document hierarchy into LevelDB,
+        // storing each embedded document under its own `_key`. Embedded items
+        // therefore need a hierarchical key, as do any effects they carry
+        // (re-keyed under this actor's item rather than the items-pack key they
+        // inherited). Mirrors the items pack convention in items.mjs.
+        merged._key = `!actors.items!${actorId}.${merged._id}`;
+        if (Array.isArray(merged.effects)) {
+            for (const effect of merged.effects) {
+                if (!effect?._id) continue;
+                effect._key = `!actors.items.effects!${actorId}.${merged._id}.${effect._id}`;
+            }
+        }
         return merged;
     }
 


### PR DESCRIPTION
## Summary

Fixes the `LEVEL_INVALID_KEY` crash when compiling the `actors` pack.

Foundry's CLI flattens an actor into LevelDB, storing every embedded document
(`items`, `effects`) as its own entry keyed by `doc._key`. The actor exporter
(`utils/packs/actors.mjs#resolveEmbedded`) set each embedded item's `_id` but
never its `_key`, so `compileClassicLevel` called `batch.put(undefined, …)` and
threw as soon as the actors pack contained an actor. (The pack had no `_source/`
tree until now, so the path had never been exercised.)

`resolveEmbedded` now assigns each embedded item the hierarchical key
`!actors.items!<actorId>.<itemId>`, and re-keys any effects it carries to
`!actors.items.effects!<actorId>.<itemId>.<effectId>` — matching the items-pack
convention (`items.mjs`) and the key cascade the CLI's own unpack side produces.

Fixes #59.

## Testing

- `npm run packs:export` → actor `_source` regenerates; all 42 embedded items now
  carry a `_key`, 0 missing.
- `npm run build:compiledb` → previously failing; now prints "Pack compilation
  complete" with no error.
