### PR TITLE
chore: link all TODO/FIXME to issues and add CI guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Check TODO issue links
+              run: npm run lint:todos
+
             - name: Run tests with coverage
               run: npm run test:coverage
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "distclean": "node utils/clean.mjs --distclean",
         "build": "npm ci && npm run build:noci",
         "build:local": "npm i && npm run build:noci",
-        "build:noci": "run-s build:types build:prepare test:coverage test:purity build:code",
+        "build:noci": "run-s lint:todos build:types build:prepare test:coverage test:purity build:code",
         "build:prepare": "run-p build:css build:db build:system",
         "build:db": "run-s build:assets build:compiledb",
         "build:types": "tsc -p tsconfig.json",
@@ -78,6 +78,7 @@
         "format:check": "prettier --check .",
         "lint": "eslint src/",
         "lint:fix": "eslint src/ --fix",
+        "lint:todos": "node utils/check-todos.mjs",
         "changeset": "changeset",
         "changeset:version": "changeset version",
         "changeset:check": "changeset check"

--- a/src/document/actor/foundry/SohlActor.ts
+++ b/src/document/actor/foundry/SohlActor.ts
@@ -58,7 +58,7 @@ const { HTMLField, StringField, FilePathField } = foundry.data.fields;
  *
  * NOTE: The Foundry-free contracts (SohlActorLogic, SohlActorData, SohlActorBaseLogic)
  * now live in src/document/actor/logic/SohlActorBaseLogic.ts and are re-exported here.
- * TODO: The remaining Foundry-coupled contents (SohlActor Document, SohlActorDataModel,
+ * TODO(#77): The remaining Foundry-coupled contents (SohlActor Document, SohlActorDataModel,
  * SohlActorSheetBase) could still be split into separate files per concern.
  */
 export class SohlActor extends Actor {
@@ -309,7 +309,7 @@ export class SohlActor extends Actor {
      * @param btn The button element that was clicked.
      */
     async onChatCardEditAction(btn: HTMLElement): Promise<void> {
-        // TODO: Handle chat card edit actions here
+        // TODO(#66): Handle chat card edit actions here
         console.log("Edit action clicked:", btn);
     }
 

--- a/src/document/actor/logic/CohortLogic.ts
+++ b/src/document/actor/logic/CohortLogic.ts
@@ -67,7 +67,7 @@ import {
  * @typeParam TData - The Cohort data interface.
  */
 /**
- * TODO: Shared Gear Tab
+ * TODO(#76): Shared Gear Tab
  * The Cohort sheet should provide a "Shared Gear" tab that aggregates
  * gear items from all member actors whose `sharedWithCohortIds` includes
  * this cohort's actor ID. This gives a single-glance view of all

--- a/src/document/item/foundry/SohlItem.ts
+++ b/src/document/item/foundry/SohlItem.ts
@@ -23,8 +23,6 @@ import type { SohlTriggerContext } from "@src/core/SohlEventTrigger";
 import { isScriptActionMutationAllowed } from "@src/domain/action/SohlAction";
 import { GearLogic } from "../logic/GearLogic";
 const { HTMLField } = foundry.data.fields;
-// TODO: This still uses the deprecated global TextEditor. Should use the
-// FoundryHelpers shim (enrichHTML) like Being.ts does, for consistency.
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
 type RenderContext =
     foundry.applications.api.DocumentSheetV2.RenderContext<SohlItem>;
@@ -32,7 +30,7 @@ type RenderOptions = foundry.applications.api.DocumentSheetV2.RenderOptions;
 
 // NOTE: The Foundry-free contracts (SohlItemLogic, SohlItemData, SohlItemBaseLogic)
 // now live in src/document/item/logic/SohlItemBaseLogic.ts and are re-exported here.
-// TODO: The remaining Foundry-coupled contents (SohlItem Document, SohlItemDataModel,
+// TODO(#77): The remaining Foundry-coupled contents (SohlItem Document, SohlItemDataModel,
 // SohlItemSheetBase) could still be split into separate files per concern.
 /**
  * Base class for all Item documents in the SoHL system — affiliations,
@@ -265,7 +263,7 @@ export class SohlItem extends Item {
      * @param btn The button element that was clicked.
      */
     async onChatCardEditAction(btn: HTMLElement): Promise<void> {
-        // TODO: Handle chat card edit actions here
+        // TODO(#66): Handle chat card edit actions here
         console.log("Edit action clicked:", btn);
     }
 

--- a/src/document/item/logic/AfflictionLogic.ts
+++ b/src/document/item/logic/AfflictionLogic.ts
@@ -183,7 +183,7 @@ export class AfflictionLogic<
      * @remarks Not yet implemented; always returns `true`.
      */
     get canTransmit(): boolean {
-        // TODO - Implement Affliction canTransmit
+        // TODO(#67) - Implement Affliction canTransmit
         return true;
     }
 
@@ -193,7 +193,7 @@ export class AfflictionLogic<
      * @remarks Not yet implemented; always returns `true`.
      */
     get canContract(): boolean {
-        // TODO - Implement Affliction canContract
+        // TODO(#67) - Implement Affliction canContract
         return true;
     }
 
@@ -204,7 +204,7 @@ export class AfflictionLogic<
      * @remarks Not yet implemented; always returns `true`.
      */
     get hasCourse(): boolean {
-        // TODO - Implement Affliction hasCourse
+        // TODO(#67) - Implement Affliction hasCourse
         return true;
     }
 
@@ -214,7 +214,7 @@ export class AfflictionLogic<
      * @remarks Not yet implemented; always returns `true`.
      */
     get canTreat(): boolean {
-        // TODO - Implement Affliction canTreat
+        // TODO(#67) - Implement Affliction canTreat
         return true;
     }
 
@@ -224,7 +224,7 @@ export class AfflictionLogic<
      * @remarks Not yet implemented; always returns `true`.
      */
     get canHeal(): boolean {
-        // TODO - Implement Affliction canHeal
+        // TODO(#67) - Implement Affliction canHeal
         return true;
     }
 
@@ -239,7 +239,7 @@ export class AfflictionLogic<
             type = `affliction-${this.name}-transmit`,
             title = `${this.label} Transmit`,
         } = context;
-        // TODO - Affliction Transmit
+        // TODO(#68) - Affliction Transmit
         sohl.log.warn("Affliction Transmit Not Implemented");
     }
 
@@ -259,7 +259,7 @@ export class AfflictionLogic<
             title = `${this.label} Contract Test`,
         } = context;
 
-        // TODO - Affliction Contract Test
+        // TODO(#68) - Affliction Contract Test
         throw new Error("Affliction Contract Test Not Implemented");
     }
 
@@ -279,7 +279,7 @@ export class AfflictionLogic<
             title = `${this.label} Course Test`,
         } = context;
 
-        // TODO - Affliction Course Test
+        // TODO(#68) - Affliction Course Test
         throw new Error("Affliction Course Test Not Implemented");
     }
 
@@ -299,7 +299,7 @@ export class AfflictionLogic<
             title = `${this.label} Diagnosis Test`,
         } = context;
 
-        // TODO - Affliction Diagnosis Test
+        // TODO(#68) - Affliction Diagnosis Test
         throw new Error("Affliction Diagnosis Test Not Implemented");
     }
 
@@ -319,7 +319,7 @@ export class AfflictionLogic<
             title = `${this.label} Treatment Test`,
         } = context;
 
-        // TODO - Affliction Treatment Test
+        // TODO(#68) - Affliction Treatment Test
         throw new Error("Affliction Treatment Test Not Implemented");
     }
 
@@ -339,7 +339,7 @@ export class AfflictionLogic<
             title = `${this.label} Healing Test`,
         } = context;
 
-        // TODO - Affliction Healing Test
+        // TODO(#68) - Affliction Healing Test
         throw new Error("Affliction Healing Test Not Implemented");
     }
 
@@ -377,7 +377,7 @@ export class AfflictionLogic<
                 scope: SOHL_ACTION_SCOPE.SELF,
                 iconFAClass: "sohl-heart-beats",
                 executor: "courseTest",
-                // FIXME: original gated on actor's endurance and item.system.isDormant;
+                // FIXME(#65): original gated on actor's endurance and item.system.isDormant;
                 // reduced to "true" pending a proper implementation.
                 visible: "true",
                 group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
@@ -419,7 +419,7 @@ export class AfflictionLogic<
                 scope: SOHL_ACTION_SCOPE.SELF,
                 iconFAClass: "sohl-caduceus",
                 executor: "treatmentTest",
-                // FIXME: original gated on actor's "pysn" skill and item.system.isBleeding;
+                // FIXME(#65): original gated on actor's "pysn" skill and item.system.isBleeding;
                 // reduced to "true" pending a proper implementation.
                 visible: "true",
                 group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
@@ -439,7 +439,7 @@ export class AfflictionLogic<
                 title: "SOHL.Affliction.Action.HEALINGTEST",
                 iconFAClass: "sohl-healing",
                 executor: "healingTest",
-                // FIXME: original gated on actor's endurance and item.system.isBleeding;
+                // FIXME(#65): original gated on actor's endurance and item.system.isBleeding;
                 // reduced to "true" pending a proper implementation.
                 visible: "true",
                 group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,

--- a/src/document/item/logic/GearLogic.ts
+++ b/src/document/item/logic/GearLogic.ts
@@ -67,7 +67,7 @@ export abstract class GearLogic<
      * Populated during {@link initialize} by looking up each cohort ID
      * in the world actor collection.
      *
-     * TODO: The Cohort sheet should query all member actors' gear items
+     * TODO(#76): The Cohort sheet should query all member actors' gear items
      * for entries whose sharedWithCohortIds includes its own actor ID,
      * and display them on a dedicated "Shared Gear" tab. This gives a
      * single-glance view of all equipment owned by the cohort without

--- a/src/document/item/logic/SkillLogic.ts
+++ b/src/document/item/logic/SkillLogic.ts
@@ -39,7 +39,7 @@ import {
 import { AttributeLogic } from "./AttributeLogic";
 import { SohlAction } from "@src/domain/action/SohlAction";
 
-// TODO: This needs to be internationalized
+// TODO(#70): This needs to be internationalized
 const FATE_DESC_TABLE: SuccessTestResult.LimitedDescription[] = [
     {
         maxValue: -1,
@@ -216,7 +216,7 @@ export class SkillLogic<
     async fateTest(context: SohlActionContext): Promise<void> {
         if (this.fateMasteryLevel.disabled) return;
 
-        //TODO: Need to figure out which fate items to consume here
+        //TODO(#71): Need to figure out which fate items to consume here
         const fateItem = this.availableFate.find(
             (it) =>
                 (it.logic as unknown as MysteryLogic).charges.value.effective >
@@ -297,7 +297,7 @@ export class SkillLogic<
                     ),
             resultDesc:
                 isSuccess ?
-                    //TODO: "{label} increased by {incr} to {final}"
+                    //TODO(#70): "{label} increased by {incr} to {final}"
                     sohl.i18n.format(
                         "SOHL.MasteryLevel.improveSDR.increase.desc",
                         {
@@ -375,7 +375,7 @@ export class SkillLogic<
      */
     get availableFate(): SohlItem[] {
         let result: SohlItem[] = [];
-        // TODO: Implement this properly
+        // TODO(#71): Implement this properly
         // if (!this.masteryLevel.disabled && this.actor) {
         //     this.actor.allItems.forEach((it: SohlItem) => {
         //         if (it.type === ITEM_KIND.MYSTERY) {

--- a/src/domain/modifier/MasteryLevelModifier.ts
+++ b/src/domain/modifier/MasteryLevelModifier.ts
@@ -29,7 +29,7 @@ import {
 } from "@src/utils/constants";
 import { SohlActionContext } from "@src/core/SohlActionContext";
 
-// TODO: This needs to be internationalized
+// TODO(#70): This needs to be internationalized
 const STANDARD_SUCCESS_VALUE_TABLE: SuccessTestResult.LimitedDescription[] = [
     {
         maxValue: 0,
@@ -393,7 +393,7 @@ export class MasteryLevelModifier extends ValueModifier {
      * @returns The evaluated {@link SuccessTestResult}, `null` if cancelled, or
      *   `false` on error.
      */
-    // TODO(doc): the locally-built success-value scope (svTable / targetValueFunc)
+    // TODO(#78): the locally-built success-value scope (svTable / targetValueFunc)
     // is not currently passed into successTest — confirm the intended wiring.
     async successValueTest(
         context: SohlActionContext,

--- a/src/domain/result/SuccessTestResult.ts
+++ b/src/domain/result/SuccessTestResult.ts
@@ -384,7 +384,7 @@ export class SuccessTestResult extends TestResult {
                     throw new Error(`Invalid roll mode "${formData.rollMode}"`);
                 }
 
-                // FIXME
+                // FIXME(#75)
                 // if (isMovement(data.targetMovement)) {
                 //     this.targetMovement = data.targetMovement;
                 // } else {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2084,7 +2084,7 @@ export const {
         id: "dodgeTest",
         name: "Dodge Test",
         iconClass: "sohl-dodge",
-        // FIXME: original walked actor.items.find for a usable "Dodge" skill;
+        // FIXME(#64): original walked actor.items.find for a usable "Dodge" skill;
         // reduce to "true" until SafeExpression supports collection iteration.
         condition: "true",
         group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,

--- a/utils/check-todos.mjs
+++ b/utils/check-todos.mjs
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * CI guard: every `TODO`/`FIXME` comment in `src/` must reference a tracking
+ * issue, written as `TODO(#123)` / `FIXME(#123)`. Deferred work belongs in
+ * issues, not in floating code comments that drift out of sync.
+ *
+ * Only `TODO`/`FIXME` are enforced (not `HACK`/`XXX`), and only inside
+ * comments — string-literal contents are ignored so values like `"XXX"` or a
+ * quoted `"TODO"` never trip the check. Exits non-zero on any violation.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "src";
+const ENFORCED = /\b(?:TODO|FIXME)\b/;
+const LINKED = /\b(?:TODO|FIXME)\(#\d+\)/;
+
+/** @returns {Generator<string>} every `.ts` file under `dir`, recursively. */
+function* walk(dir) {
+    for (const name of readdirSync(dir)) {
+        const p = join(dir, name);
+        if (statSync(p).isDirectory()) yield* walk(p);
+        else if (p.endsWith(".ts")) yield p;
+    }
+}
+
+const violations = [];
+for (const file of walk(ROOT)) {
+    const lines = readFileSync(file, "utf8").split("\n");
+    lines.forEach((line, i) => {
+        // Blank out string/template-literal contents so markers inside strings
+        // are not flagged.
+        const code = line.replace(
+            /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`/g,
+            '""',
+        );
+        // Restrict the check to the comment portion of the line.
+        const comment = code.match(/\/\/.*|\/\*.*|^\s*\*.*/)?.[0];
+        if (!comment) return;
+        if (ENFORCED.test(comment) && !LINKED.test(comment)) {
+            violations.push(`${file}:${i + 1}: ${line.trim()}`);
+        }
+    });
+}
+
+if (violations.length) {
+    console.error(
+        `\ncheck-todos: ${violations.length} TODO/FIXME without an issue reference:\n`,
+    );
+    for (const v of violations) console.error(`  ${v}`);
+    console.error(
+        "\nEvery TODO/FIXME in committed code must reference a tracking issue, " +
+            "e.g. TODO(#123).\nFile or find an issue and link it, or remove the comment.\n",
+    );
+    process.exit(1);
+}
+console.log("check-todos: all TODO/FIXME markers reference a tracking issue.");


### PR DESCRIPTION
## Summary

Adopts the "no orphan TODOs" rule: every `TODO`/`FIXME` in committed code must
reference a tracking issue. This PR brings `main` into compliance and adds a CI
guard so it can't rot again.

- **Linked** all 28 surviving `TODO`/`FIXME` markers in `src/` to their tracking
  issues (`TODO(#123)` form) — #64–#68, #70, #71, #75–#78.
- **Deleted** the stale `TextEditor` migration TODO in `SohlItem.ts` (the code
  already uses `foundry.applications.ux.TextEditor.implementation`; the comment
  was outdated).
- **Added** `utils/check-todos.mjs` (`npm run lint:todos`), wired into
  `build:noci` and a dedicated `build.yml` step. It fails the build on any
  `TODO`/`FIXME` lacking `(#\d+)`. Only `TODO`/`FIXME` are enforced (not
  `HACK`/`XXX`), and matches inside string literals are ignored.

No behavior change — comments and tooling only. No changeset (chore).

## Note

The `bug/issue_62_intrinsic-action-executors` branch carries additional TODOs
(weapon direct combat, Use Mystery, trauma tests, mystical-ability perform) that
aren't in `main`. Once this guard merges, that branch's CI will require those to
be linked to #69/#72/#73/#74 before it can merge — by design.

## Testing

- `npm run lint:todos` — passes (0 unlinked markers).
- `npm run build:types` — clean.
- Negative test confirms the guard flags bare `TODO`/`FIXME`, accepts
  `TODO(#42)`, and ignores `"XXX"` / quoted markers.