### PR TITLE
chore(ci): generate docbundle before building API docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
               run: npm run build
 
             - name: Build API documentation
-              run: npm run docs:html
+              run: npm run docs:prepare && npm run docs:html
 
             - name: Upload API Documentation
               if: always()


### PR DESCRIPTION
## Problem

The non-main **Build & Test** workflow has been red on *every* branch. The "Build API
documentation" step runs `npm run docs:html` directly, but typedoc's entry points live in
`build/docbundle/`, which is generated by `docs:prepare` (`docs:catalog` + `docs:bundle`).
On a clean CI runner that directory doesn't exist, so typedoc fails:

```
[warning] The glob ./build/docbundle did not match any files
[error] Unable to find any entry points. See previous warnings
```

Locally it appeared to pass only because of a stale `build/docbundle/All.ts` left by a prior build.

## Fix

Run `docs:prepare` before `docs:html` in the workflow step, matching the documented docs
build in CLAUDE.md (`npm run docs:prepare && npm run docs:html`).

## Verification

From a clean `build/docbundle` (simulating a fresh runner):

- `npm run docs:html` alone → fails with `Unable to find any entry points`.
- `npm run docs:prepare && npm run docs:html` → exit 0, `build/stage/docs/index.html` generated
  (0 errors, warnings only).

Unblocks the non-main CI for all branches.

