### PR TITLE
chore: link TODOs introduced by #63 to tracking issues

### DIFF
--- a/src/document/item/logic/AfflictionLogic.ts
+++ b/src/document/item/logic/AfflictionLogic.ts
@@ -355,7 +355,7 @@ export class AfflictionLogic<
     async fatigueTest(
         _context: SohlActionContext,
     ): Promise<SuccessTestResult | null> {
-        // TODO - Affliction Fatigue Test
+        // TODO(#68) - Affliction Fatigue Test
         sohl.log.uiWarn("Affliction Fatigue Test is not yet implemented.");
         return null;
     }
@@ -372,7 +372,7 @@ export class AfflictionLogic<
     async moraleTest(
         _context: SohlActionContext,
     ): Promise<SuccessTestResult | null> {
-        // TODO - Affliction Morale Test
+        // TODO(#68) - Affliction Morale Test
         sohl.log.uiWarn("Affliction Morale Test is not yet implemented.");
         return null;
     }
@@ -389,7 +389,7 @@ export class AfflictionLogic<
     async fearTest(
         _context: SohlActionContext,
     ): Promise<SuccessTestResult | null> {
-        // TODO - Affliction Fear Test
+        // TODO(#68) - Affliction Fear Test
         sohl.log.uiWarn("Affliction Fear Test is not yet implemented.");
         return null;
     }

--- a/src/document/item/logic/MysteryLogic.ts
+++ b/src/document/item/logic/MysteryLogic.ts
@@ -111,7 +111,7 @@ export class MysteryLogic<
      * @remarks Not yet implemented; warns and returns.
      */
     async useMystery(_context: SohlActionContext): Promise<void> {
-        // TODO - Use Mystery
+        // TODO(#72) - Use Mystery
         sohl.log.uiWarn(`Using "${this.name}" is not yet implemented.`);
     }
 

--- a/src/document/item/logic/MysticalAbilityLogic.ts
+++ b/src/document/item/logic/MysticalAbilityLogic.ts
@@ -138,7 +138,7 @@ export class MysticalAbilityLogic<
     async perform(
         _context: SohlActionContext,
     ): Promise<SuccessTestResult | null> {
-        // TODO - Mystical Ability Perform
+        // TODO(#74) - Mystical Ability Perform
         sohl.log.uiWarn(
             `Performing "${this.name}" is not yet implemented.`,
         );

--- a/src/document/item/logic/TraumaLogic.ts
+++ b/src/document/item/logic/TraumaLogic.ts
@@ -96,7 +96,7 @@ export class TraumaLogic<
     async treatmentTest(
         _context: SohlActionContext,
     ): Promise<SuccessTestResult | null> {
-        // TODO - Trauma Treatment Test
+        // TODO(#73) - Trauma Treatment Test
         sohl.log.uiWarn("Trauma Treatment Test is not yet implemented.");
         return null;
     }
@@ -113,7 +113,7 @@ export class TraumaLogic<
     async healingTest(
         _context: SohlActionContext,
     ): Promise<SuccessTestResult | null> {
-        // TODO - Trauma Healing Test
+        // TODO(#73) - Trauma Healing Test
         sohl.log.uiWarn("Trauma Healing Test is not yet implemented.");
         return null;
     }

--- a/src/document/item/logic/WeaponGearLogic.ts
+++ b/src/document/item/logic/WeaponGearLogic.ts
@@ -193,7 +193,7 @@ export class WeaponGearLogic<
      *   flow ({@link automatedCombatStart}) is the supported entry point.
      */
     async attack(_context: SohlActionContext): Promise<void> {
-        // TODO - Weapon direct attack
+        // TODO(#69) - Weapon direct attack
         sohl.log.uiWarn(
             `A direct attack with "${this.name}" is not yet implemented.`,
         );
@@ -208,7 +208,7 @@ export class WeaponGearLogic<
      * @remarks Not yet implemented; warns and returns.
      */
     async block(_context: SohlActionContext): Promise<void> {
-        // TODO - Weapon direct block
+        // TODO(#69) - Weapon direct block
         sohl.log.uiWarn(
             `A direct block with "${this.name}" is not yet implemented.`,
         );
@@ -223,7 +223,7 @@ export class WeaponGearLogic<
      * @remarks Not yet implemented; warns and returns.
      */
     async counterstrike(_context: SohlActionContext): Promise<void> {
-        // TODO - Weapon direct counterstrike
+        // TODO(#69) - Weapon direct counterstrike
         sohl.log.uiWarn(
             `A direct counterstrike with "${this.name}" is not yet implemented.`,
         );


### PR DESCRIPTION
## Problem

PR #63 added 10 unreferenced `TODO` markers in the item logic layer. PR #79's
`lint:todos` guard merged afterward and now correctly flags them, so `main` is red
on its own guard — the "Check TODO issue links" CI step fails on every branch.

These two PRs each passed independently but combined into a broken `main`.

## Fix

Link each TODO to its existing tracking issue (comment-only, no behavior change):

| File:lines | Issue |
| --- | --- |
| `AfflictionLogic.ts:358/375/392` — Fatigue/Morale/Fear tests | #68 |
| `WeaponGearLogic.ts:196/211/226` — direct attack/block/counterstrike | #69 |
| `MysteryLogic.ts:114` — Use Mystery | #72 |
| `TraumaLogic.ts:99/116` — Treatment/Healing tests | #73 |
| `MysticalAbilityLogic.ts:141` — Mystical Ability Perform | #74 |

## Verification

`npm run lint:todos` → "all TODO/FIXME markers reference a tracking issue."
With the docs-CI fix (#85) already on `main`, this turns the non-main Build & Test
workflow green again and unblocks all branches.

