### PR TITLE
cleanup(css): extract reusable list-widget component (#93)

### DIFF
--- a/.changeset/css-list-component.md
+++ b/.changeset/css-list-component.md
@@ -1,0 +1,26 @@
+---
+"sohl": patch
+---
+
+**Extract the reusable list-widget component (DRY items/effects/body-location)**
+
+The item, effect, and body-location lists each re-implemented the same skeleton —
+scrollable body, header row, reset inner list, control cluster, and the
+ellipsis-truncation triple repeated on nearly every column. Extract that skeleton into
+shared mixins so the three lists become thin consumers:
+
+- `abstracts/_mixins.scss` gains `truncate` (the `text-overflow`/`white-space`/`overflow`
+  ellipsis triple used ~15× across the lists).
+- New `components/_list.scss` provides the list mixins: `scroll-body`, `reset`,
+  `section-title`, `header-row`, and `controls` (emits no CSS itself).
+- `components/_items.scss`, `_effects.scss`, and `_bodyloc.scss` now `@include` those
+  mixins and keep only their own columns and accent colors.
+
+Class names are unchanged, so **templates are untouched** and the compiled CSS is
+equivalent: the only diff against the previous build is a cosmetic `margin: 7px 0px` →
+`margin: 7px 0` normalization (identical computed value) on the body-location list.
+
+Scope note: the header duplication this epic targeted (`.sheet-header-being/-object`) was
+already removed in the dead-code pass, and the form field was split into its own partial
+in the folder reorg; the remaining BEM-driven shared-class adoption in templates lands in
+the naming pass.

--- a/scss/abstracts/_mixins.scss
+++ b/scss/abstracts/_mixins.scss
@@ -14,3 +14,11 @@
 @mixin hide {
     display: none;
 }
+
+// Single-line overflow ellipsis. Repeated across every list column, so it lives
+// here as the canonical helper.
+@mixin truncate {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}

--- a/scss/components/_bodyloc.scss
+++ b/scss/components/_bodyloc.scss
@@ -1,9 +1,9 @@
+@use "../abstracts/mixins";
+@use "list";
+
 .bodylocations {
     .zone-list {
-        list-style: none;
-        margin: 7px 0px;
-        padding: 0;
-        overflow-y: hidden;
+        @include list.scroll-body;
         line-height: normal;
 
         .body-drop {
@@ -40,9 +40,7 @@
 
         .bodylocation-name {
             flex: 0 0 120px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
             padding-left: 5px;
         }
 
@@ -50,9 +48,7 @@
             flex: 0 0 120px;
             text-align: left;
             padding-left: 10px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .bodylocation-part {
@@ -67,9 +63,7 @@
         .bodylocation-notes {
             flex: 1 0 100px;
             padding-left: 10px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .zone-header {
@@ -88,9 +82,7 @@
 
             .zone-name {
                 flex: 0 0 140px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
                 padding-left: 5px;
 
                 h4 {
@@ -102,17 +94,13 @@
                 flex: 0 0 100px;
                 text-align: left;
                 padding-left: 10px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
             }
 
             .zone-notes {
                 flex: 1 0 100px;
                 padding-left: 10px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
             }
         }
 
@@ -132,9 +120,7 @@
 
             .bodypart-name {
                 flex: 0 0 130px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
                 padding-left: 5px;
                 border-right: 1px solid var(--sohl-color-border-default);
 
@@ -146,9 +132,7 @@
             .bodypart-notes {
                 flex: 1 0 100px;
                 padding-left: 10px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
             }
         }
     }

--- a/scss/components/_effects.scss
+++ b/scss/components/_effects.scss
@@ -1,16 +1,13 @@
-@use "../abstracts/typography";
+@use "../abstracts/mixins";
+@use "list";
 
 .effects {
     h2 {
-        flex: 1;
-        margin: 0;
-        line-height: 36px;
-        @include typography.type-style("label");
-        color: var(--sohl-color-text-muted);
-        background-color: var(--sohl-color-border-default);
-        border-top: 2px groove var(--sohl-color-text-inverse);
-        border-bottom: 2px groove var(--sohl-color-text-inverse);
-        padding: 5px;
+        @include list.section-title(
+            var(--sohl-color-text-muted),
+            var(--sohl-color-border-default),
+            var(--sohl-color-text-inverse)
+        );
     }
 
     .danger {
@@ -22,33 +19,19 @@
     }
 
     .effects-list {
-        list-style: none;
-        margin: 7px 0;
-        padding: 0;
-        overflow-y: hidden;
+        @include list.scroll-body;
 
         .effects-header {
-            margin: 2px 0;
-            padding: 0;
-            align-items: center;
-            background: var(--sohl-color-bg-overlay-dark);
-            border: 2px groove var(--sohl-color-border-subtle);
-            font-weight: bold;
-            line-height: 24px;
-
-            h3 {
-                margin: 0;
-                padding-left: 5px;
-                @include typography.type-style("label-small");
-            }
+            @include list.header-row(
+                var(--sohl-color-bg-overlay-dark),
+                var(--sohl-color-border-subtle)
+            );
 
             .name {
                 color: var(--sohl-color-text-primary);
                 flex: 0 0 150px;
                 border-right: 1px solid var(--sohl-color-border-default);
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
 
                 i {
                     font-size: 12px;
@@ -65,16 +48,12 @@
         }
 
         .effect-list {
-            list-style: none;
-            margin: 0;
-            padding: 0;
+            @include list.reset;
         }
 
         .effect {
             border-bottom: 1px solid var(--sohl-color-border-default);
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
 
             .image {
                 flex: 0 0 30px;
@@ -90,9 +69,7 @@
                 flex: 0 0 150px;
                 max-height: 30px;
                 border-right: 1px solid var(--sohl-color-border-default);
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
 
                 h4 {
                     margin: 0;
@@ -123,34 +100,25 @@
             flex: 0 0 150px;
             text-align: center;
             padding-left: 5px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .target {
             flex: 0 0 150px;
             text-align: center;
             padding-left: 5px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .changes {
             flex: 1 0 60px;
             text-align: left;
             padding-left: 5px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .effect-controls {
-            flex: 0 0 45px;
-            text-align: right;
-            padding-right: 5px;
-            font-size: 12px;
+            @include list.controls(45px);
             color: var(--sohl-color-text-primary);
 
             .effect-control {

--- a/scss/components/_items.scss
+++ b/scss/components/_items.scss
@@ -1,16 +1,13 @@
-@use "../abstracts/typography";
+@use "../abstracts/mixins";
+@use "list";
 
 .items {
     h2 {
-        flex: 1;
-        margin: 0;
-        line-height: 36px;
-        @include typography.type-style("label");
-        color: var(--sohl-color-text-primary);
-        background-color: var(--sohl-color-bg-header);
-        border-top: 2px groove var(--sohl-color-border-subtle);
-        border-bottom: 2px groove var(--sohl-color-border-subtle);
-        padding: 5px;
+        @include list.section-title(
+            var(--sohl-color-text-primary),
+            var(--sohl-color-bg-header),
+            var(--sohl-color-border-subtle)
+        );
     }
 
     .danger {
@@ -26,28 +23,16 @@
     }
 
     .items-list {
-        list-style: none;
-        margin: 7px 0;
-        padding: 0;
-        overflow-y: hidden;
+        @include list.scroll-body;
 
         .items-header {
-            margin: 2px 0;
-            padding: 0;
-            align-items: center;
-            background: var(--sohl-color-bg-overlay-dark);
-            border: 2px groove var(--sohl-color-border-subtle);
-            font-weight: bold;
-            line-height: 24px;
+            @include list.header-row(
+                var(--sohl-color-bg-overlay-dark),
+                var(--sohl-color-border-subtle)
+            );
 
-            h3 {
-                margin: 0;
-                padding-left: 5px;
-                @include typography.type-style("label-small");
-
-                .fas {
-                    padding-right: 5px;
-                }
+            h3 .fas {
+                padding-right: 5px;
             }
 
             .item-name {
@@ -64,9 +49,7 @@
                 flex: 0 0 140px;
                 text-align: right;
                 padding-right: 10px;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
+                @include mixins.truncate;
             }
 
             .overmaxcap {
@@ -81,9 +64,7 @@
         }
 
         .item-list {
-            list-style: none;
-            margin: 0;
-            padding: 0;
+            @include list.reset;
         }
 
         .name {
@@ -113,18 +94,13 @@
                 white-space: nowrap;
                 overflow-x: hidden;
                 text-overflow: ellipsis;
-                white-space: nowrap;
             }
         }
 
         .detail {
             font-size: 12px;
             border-right: 1px solid var(--sohl-color-border-default);
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .notes {
@@ -153,9 +129,7 @@
             text-align: center;
             padding-left: 1px;
             padding-right: 1px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
 
             .value {
                 padding-left: 3px;
@@ -166,9 +140,7 @@
             flex: 0 0 120px;
             text-align: left;
             padding-left: 5px;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            overflow: hidden;
+            @include mixins.truncate;
         }
 
         .aspect {
@@ -177,10 +149,7 @@
         }
 
         .item-controls {
-            flex: 0 0 45px;
-            text-align: right;
-            padding-right: 5px;
-            font-size: 12px;
+            @include list.controls(45px);
 
             .item-control {
                 flex: 0 0 22px;
@@ -188,10 +157,7 @@
         }
 
         .item-controls-wide {
-            flex: 0 0 65px;
-            text-align: right;
-            padding-right: 5px;
-            font-size: 12px;
+            @include list.controls(65px);
 
             .item-control {
                 flex: 0 0 22px;

--- a/scss/components/_list.scss
+++ b/scss/components/_list.scss
@@ -1,0 +1,61 @@
+// Reusable list-widget scaffolding. The item, effect, and body-location lists
+// share the same skeleton — a scrollable body, a header row, an inner reset
+// list, a control cluster — and differ only in their columns and accent colors.
+// These mixins are that skeleton; the list partials consume them and add only
+// their own columns. Emits no CSS on its own (mixins only).
+
+@use "../abstracts/typography";
+
+// The outer `<ul>`/`<ol>` that holds a list's header + rows.
+@mixin scroll-body {
+    list-style: none;
+    margin: 7px 0;
+    padding: 0;
+    overflow-y: hidden;
+}
+
+// A bare inner list (no bullets, no spacing).
+@mixin reset {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+// The `<h2>` section title above a list. Color/background/border vary per list.
+@mixin section-title($color, $background, $border) {
+    flex: 1;
+    margin: 0;
+    line-height: 36px;
+    @include typography.type-style("label");
+    color: $color;
+    background-color: $background;
+    border-top: 2px groove $border;
+    border-bottom: 2px groove $border;
+    padding: 5px;
+}
+
+// The column-label header row, including the shared `h3` label styling.
+@mixin header-row($background, $border) {
+    margin: 2px 0;
+    padding: 0;
+    align-items: center;
+    background: $background;
+    border: 2px groove $border;
+    font-weight: bold;
+    line-height: 24px;
+
+    h3 {
+        margin: 0;
+        padding-left: 5px;
+        @include typography.type-style("label-small");
+    }
+}
+
+// The right-aligned control cluster at the end of a header/row. `$width` covers
+// the narrow (45px) and wide (65px) variants.
+@mixin controls($width: 45px) {
+    flex: 0 0 $width;
+    text-align: right;
+    padding-right: 5px;
+    font-size: 12px;
+}


### PR DESCRIPTION
Closes #93. Fifth child of epic #95 — the reusable-component payoff, scoped to the **list widget family** per the issue's "component-by-component, one widget per PR" allowance.

## What

The item, effect, and body-location lists each re-implemented the same skeleton — scrollable body, header row, reset inner list, control cluster — and repeated the `text-overflow: ellipsis; white-space: nowrap; overflow: hidden` triple on nearly every column. Extracted into shared mixins so the three lists become thin consumers:

- **`abstracts/_mixins.scss`** — new `truncate` mixin (the ellipsis triple, used ~15× across the lists).
- **`components/_list.scss`** (new) — the list mixins `scroll-body`, `reset`, `section-title`, `header-row`, `controls`. Pure mixin library; emits no CSS itself.
- **`components/_items.scss`, `_effects.scss`, `_bodyloc.scss`** — now `@include` the mixins and keep only their own columns and accent colors.

Class names are unchanged, so **templates are untouched** and the work is provably output-equivalent. Renaming to shared BEM classes in templates is the naming pass (#94).

## Equivalence proof

Compiled this branch vs `main` and diffed the selector and declaration sets:

```
SELECTOR set diff:    IDENTICAL
DECLARATION set diff: 1 line —  < margin: 7px 0px   (only in old)
```

The single diff is the body-location list's `margin: 7px 0px` being normalized to `margin: 7px 0` by the shared `scroll-body` mixin — an identical computed value (`0px` ≡ `0`). Everything else is byte-for-byte the same rule set.

## AC coverage

- **List widget** → extracted as `components/_list.scss` + `abstracts` `truncate`; items/effects/body-location are thin consumers. ✓
- **No remaining near-duplicate blocks across the three list files** → they now share the mixins. ✓
- **Header** → the duplication this epic flagged (`.sheet-header-being/-object`) was already deleted in the dead-code pass (#90); the single live `.sheet-header` has no duplicate to extract. Parameterizing it as a dedicated component is deferred to the BEM pass (#94).
- **Field / control** → the form field was split into `components/_field.scss` in the reorg (#92); the control cluster is now the `controls()` mixin. The per-context `.item-control`/`.effect-control` button and template class-renames are left for #94.

## Checks
- `npm run build:css`, `npm run build` (64 tests), `npm run docs` (0 errors) — all pass.

## Remaining gate
Output-equivalent (proven above), so no visual delta is expected — but as with the rest of the epic I can't run Foundry, so the `npm run push:qa` visual pass on the actor/item sheets (inventory, effects, body-locations) is the human sign-off.
