### PR TITLE
cleanup(css): apply BEM to header and facade components (#94 part 1)

### DIFF
--- a/.changeset/css-bem-header-facade.md
+++ b/.changeset/css-bem-header-facade.md
@@ -1,0 +1,29 @@
+---
+"sohl": patch
+---
+
+**Apply BEM naming to the header and facade components (part 1 of the naming pass)**
+
+First slice of the BEM renaming capstone, scoped to the two component families whose CSS
+classes are **not** referenced from `src/` (no JS selectors) and whose state is
+template-driven — so the rename is a pure SCSS + template change with no behavioral risk:
+
+- **Header block** (`scss/layout/_sheet.scss` + the 8 `*/header.hbs` templates):
+  `header-details → sheet-header__details`, `actor-img → sheet-header__portrait`,
+  `status-effects → sheet-header__statuses`, `toggle-status-effect → sheet-header__status`.
+- **Facade** (`scss/components/_facade.scss` + `facade.hbs`):
+  `facade-image → facade__image`, `facade-description → facade__description`.
+
+SCSS and templates are renamed in lockstep (verified: zero remaining references to the old
+names anywhere in `scss/`, `templates/`, or `src/`). `data-*` attributes, `data-action` /
+`data-tab` values, localization keys, the generic `.active` state class, and Foundry-owned
+classes (`flexrow`, …) are left unchanged. The `.sohl` / `.sohl.sheet` wrappers are kept,
+so specificity is unchanged.
+
+The styleguide (`docs/concepts/css-architecture.md` §3) is updated to nail down the
+convention: BEM block names are namespaced by the `.sohl` wrapper (no redundant `sohl-`
+prefix), and Foundry/JS-owned classes and `data-*`/`lang` keys are explicitly off-limits.
+
+Remaining BEM clusters (the list classes, which are entangled with the `SearchFilter`
+`contentSelector`s in `BeingSheet.ts`, and the state-modifier normalization) follow in
+later per-component slices so each stays reviewable and visually verifiable.

--- a/docs/concepts/css-architecture.md
+++ b/docs/concepts/css-architecture.md
@@ -75,26 +75,35 @@ Migration map from the current layout:
 
 ## 3. Naming — BEM under the `.sohl` namespace
 
-**Decision: BEM (`block__element--modifier`), everything namespaced under `.sohl`.**
+**Decision: BEM (`block__element--modifier`), namespaced by the `.sohl` /
+`.sohl.sheet` wrapper rather than a per-class prefix.**
 
-Retire ad-hoc, type-suffixed, and abbreviated names. Examples of the transform:
+Every component is already emitted inside the `.sohl { }` (or compound `.sohl.sheet { }`)
+wrapper set up in `scss/sohl.scss` (§5), which provides the namespace. So BEM block names
+are written **without** a redundant `sohl-` prefix — the wrapper supplies it, and writing
+`.sohl .facade__image` keeps the same specificity as the name it replaces. Retire ad-hoc,
+type-suffixed, and abbreviated names. Examples of the transform:
 
-| Current (ad-hoc)           | Target (BEM)                                        |
-| -------------------------- | --------------------------------------------------- |
-| `.sheet-header-being`      | `.sohl-sheet__header--being`                        |
-| `.header-fields`           | `.sohl-sheet__fields`                               |
-| `.charname`                | `.sohl-sheet__name`                                 |
-| `.bodylocation-name`       | `.sohl-body-location__name`                         |
-| `.items-list` / `.item`    | `.sohl-list` / `.sohl-list__item`                   |
+| Current (ad-hoc)        | Target (BEM, under the `.sohl` wrapper) |
+| ----------------------- | --------------------------------------- |
+| `.header-details`       | `.sheet-header__details`                |
+| `.actor-img`            | `.sheet-header__portrait`               |
+| `.toggle-status-effect` | `.sheet-header__status`                 |
+| `.facade-image`         | `.facade__image`                        |
+| `.bodylocation-name`    | `.body-location__name`                  |
 
 Conventions:
 
-- One **block** per reusable widget (`sohl-list`, `sohl-header`, `sohl-field`,
-  `sohl-resource`, `sohl-effect`, `sohl-body-location`).
-- **Elements** are parts of a block (`__name`, `__value`, `__header`). **Modifiers**
+- One **block** per reusable widget (`sheet-header`, `facade`, `list`, `field`,
+  `resource`, `effect`, `body-location`).
+- **Elements** are parts of a block (`__name`, `__details`, `__portrait`). **Modifiers**
   are variants/state (`--being`, `--active`, `--danger`).
 - Prefer a modifier over a near-duplicate block. Two header blocks that differ only by
-  context become one `sohl-header` block with a modifier.
+  context become one block with a modifier.
+- **Leave these alone:** Foundry-owned classes (`window-content`, `tab`, `tabs`, `active`
+  as a Foundry/JS-toggled state, `flexrow`, `form-group`, …), `data-action` / `data-tab`
+  values, and `lang/` keys. BEM applies to **SoHL's own CSS class names only**; renaming a
+  class that JS or Foundry sets silently breaks it.
 
 **Do not rename data hooks or localization keys.** `data-*` attributes consumed by
 `src/` and `lang/en.json` keys are part of the system's contract and stay stable

--- a/scss/components/_facade.scss
+++ b/scss/components/_facade.scss
@@ -1,11 +1,11 @@
 .facade {
-    img.facade-image {
+    img.facade__image {
         flex: 0 0 200px;
         object-fit: contain;
         background: var(--sohl-color-text-inverse);
     }
 
-    .facade-description {
+    .facade__description {
         margin-left: 5px;
     }
 }

--- a/scss/layout/_sheet.scss
+++ b/scss/layout/_sheet.scss
@@ -79,7 +79,7 @@ span.sep {
 }
 
 .sheet-header {
-    .header-details {
+    .sheet-header__details {
         font-size: 20px;
         font-weight: 700;
     }
@@ -99,7 +99,7 @@ span.sep {
         }
     }
 
-    img.actor-img {
+    img.sheet-header__portrait {
         flex: 0 0 100px;
         max-width: 100px;
         height: 100px;
@@ -108,13 +108,13 @@ span.sep {
         border-right: 2px groove var(--sohl-color-border-subtle);
     }
 
-    .status-effects {
+    .sheet-header__statuses {
         display: flex;
         flex-wrap: wrap;
         gap: 4px;
         margin-top: 4px;
 
-        .toggle-status-effect {
+        .sheet-header__status {
             padding: 1px 5px;
             font-size: 11px;
             font-weight: 700;

--- a/templates/actor/assembly/header.hbs
+++ b/templates/actor/assembly/header.hbs
@@ -25,8 +25,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
 <header class="sheet-header flexrow">
-    <img class="actor-img" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
-    <div class="header-details">
+    <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
+    <div class="sheet-header__details">
         <h1 class="actor-name">
             <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
         </h1>

--- a/templates/actor/being/header.hbs
+++ b/templates/actor/being/header.hbs
@@ -25,14 +25,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
 <header class="sheet-header flexrow">
-    <img class="actor-img" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
-    <div class="header-details">
+    <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
+    <div class="sheet-header__details">
         <h1 class="actor-name">
             <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
         </h1>
-        <div class="status-effects">
+        <div class="sheet-header__statuses">
             {{#each statusEffects}}
-            <a class="toggle-status-effect {{#if this.active}}active{{/if}}" data-status-id="{{this.id}}" data-tooltip="{{this.label}}">{{this.abbr}}</a>
+            <a class="sheet-header__status {{#if this.active}}active{{/if}}" data-status-id="{{this.id}}" data-tooltip="{{this.label}}">{{this.abbr}}</a>
             {{/each}}
         </div>
     </div>

--- a/templates/actor/cohort/header.hbs
+++ b/templates/actor/cohort/header.hbs
@@ -25,8 +25,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
 <header class="sheet-header flexrow">
-    <img class="actor-img" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
-    <div class="header-details">
+    <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
+    <div class="sheet-header__details">
         <h1 class="actor-name">
             <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
         </h1>

--- a/templates/actor/parts/facade.hbs
+++ b/templates/actor/parts/facade.hbs
@@ -13,9 +13,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 <section class="tab facade{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="facade">
     <div class="flexrow">
-        <img class="facade-image" src="{{bioImage}}" data-edit="system.bioImage"
+        <img class="facade__image" src="{{bioImage}}" data-edit="system.bioImage"
             title="{{actorName}}" height="300" width="200" />
-        <div class="facade-description">
+        <div class="facade__description">
             {{editor descriptionHTML target="system.description" button=false editable=editable engine="prosemirror" collaborate=false}}
         </div>
     </div>

--- a/templates/actor/structure/header.hbs
+++ b/templates/actor/structure/header.hbs
@@ -25,8 +25,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
 <header class="sheet-header flexrow">
-    <img class="actor-img" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
-    <div class="header-details">
+    <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
+    <div class="sheet-header__details">
         <h1 class="actor-name">
             <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
         </h1>

--- a/templates/actor/vehicle/header.hbs
+++ b/templates/actor/vehicle/header.hbs
@@ -25,8 +25,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
 <header class="sheet-header flexrow">
-    <img class="actor-img" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
-    <div class="header-details">
+    <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
+    <div class="sheet-header__details">
         <h1 class="actor-name">
             <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
         </h1>

--- a/templates/item/parts/header.hbs
+++ b/templates/item/parts/header.hbs
@@ -13,7 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 <header class="sheet-header flexrow">
     <img class="item-img" src="{{itemImg}}" data-edit="img" alt="{{itemName}}" />
-    <div class="header-details">
+    <div class="sheet-header__details">
         <h1 class="item-name">
             <input name="name" type="text" value="{{itemName}}" placeholder="{{localize 'Name'}}" />
         </h1>


### PR DESCRIPTION
Part 1 of #94 (the BEM naming capstone of epic #95). Done as a per-component slice, as the issue allows ("Can be split per component to keep template churn reviewable"). **Does not close #94** — see remaining work below.

## Why a slice

#94 is the one child that crosses into runtime behavior: class names are entangled with JS `SearchFilter` `contentSelector`s, some classes are Foundry-/JS-toggled (`.active`, `flexrow`, `window-content`), and the AC explicitly requires a Foundry visual + interaction pass. So I'm landing it component-by-component, starting with the families that are **provably safe to rename statically** — no `src/` references at all.

## What

Audited every candidate class for `src/` usage first. The header and facade families have **zero** `src/` references (no JS selectors; their interactivity is `data-action`/`data-*`-driven, and `.active` is applied by a Handlebars `{{#if}}`, not JS). So they rename cleanly in SCSS + templates only:

| Old | New |
| --- | --- |
| `header-details` | `sheet-header__details` |
| `actor-img` | `sheet-header__portrait` |
| `status-effects` | `sheet-header__statuses` |
| `toggle-status-effect` | `sheet-header__status` |
| `facade-image` | `facade__image` |
| `facade-description` | `facade__description` |

Files: `scss/layout/_sheet.scss`, `scss/components/_facade.scss`, 6 `*/header.hbs`, `facade.hbs`.

## Conventions / guardrails

- **Lockstep verified:** zero remaining references to any old name across `scss/`, `templates/`, and `src/`.
- **Left unchanged:** `data-*` / `data-action` / `data-tab` values, `lang/` keys, the generic `.active` state class, and Foundry-owned classes (`flexrow`, `window-content`, …).
- **Specificity unchanged:** kept the `.sohl` / `.sohl.sheet` wrappers, so `.sohl .facade__image` has the same specificity as the name it replaces (no cascade shift).
- Styleguide §3 updated to lock the convention: BEM blocks are namespaced by the `.sohl` wrapper (no redundant `sohl-` prefix), and Foundry/JS-owned classes + `data-*`/`lang` keys are explicitly off-limits.

## Note: much of #94's named targets were already done
The issue's header bullet lists `header-fields`, `name-attribute`, `charname`, `header-stat-block`, `profile-img` to retire — those were all deleted as dead code in #90, so only `header-details` remained to BEM-ify.

## Remaining (later slices, need visual QA)
- **List classes** (`items-header`, `effects-list`, `bodylocation-name`, …) — entangled with the `BeingSheet.ts` `SearchFilter` `contentSelector`s (`.effects-list`, `.gear-list`, `.bodylocations-list`, …); these must be renamed in lockstep with `src/` and interaction-tested.
- **State-modifier normalization** (`active`/`disabled`/`none`/`impaired`/`unusable` → `--modifier`) — touches the generic `.active`/`.disabled` classes, several of which are JS/Foundry-toggled; needs per-site care.

## Checks
- `npm run build` (64 tests), `npm run build:css`, `npm run docs` (0 errors) — all pass.
- Visual: header (portrait, name, status strip) and facade are static class renames with unchanged specificity, so no visual delta is expected — but a `push:qa` glance closes the AC's visual-pass requirement.
