### PR TITLE
cleanup(css): BEM for the shared list scaffolding (#94 part 2)

### DIFF
--- a/.changeset/css-bem-list-scaffolding.md
+++ b/.changeset/css-bem-list-scaffolding.md
@@ -1,0 +1,38 @@
+---
+"sohl": patch
+---
+
+**Apply BEM to the shared list scaffolding (part 2 of the naming pass)**
+
+Unify the ad-hoc `item-*` / `items-*` scaffolding classes — used ~250× across every
+list-bearing sheet — into a single `list` BEM block, renamed in lockstep across the
+templates and `scss/components/_items.scss`:
+
+| Old | New |
+| --- | --- |
+| `items` | `list-section` |
+| `items-list` | `list` |
+| `item-list` | `list__items` |
+| `items-header` | `list__header` |
+| `item-name` | `list__name` |
+| `item-detail` | `list__detail` |
+| `item-controls` / `item-controls-wide` | `list__controls` / `list__controls--wide` |
+| `item-control` | `list__control` |
+| `item-image` | `list__image` |
+
+**Deliberately kept** (JS-coupled — renaming them would silently break behavior):
+`.item` (the row class queried by `_displayFilteredResults` for every search filter),
+`.item-contextmenu` and `.default-action` (event hooks), and the eight `SearchFilter`
+`contentSelector` classes. Generic single-word leaf columns (`.name`, `.detail`,
+`.type`, …) are left scoped under their block, and Foundry-owned classes (`flexrow`, …)
+are untouched. `data-*` / `data-action` values and `lang/` keys are unchanged.
+
+Template class lists were rewritten only inside `class="…"` attributes, so handlebars
+expressions and `data-*` are unaffected; verified zero orphaned old tokens remain in
+`scss/` or `templates/`. The rename is consistent (wrapper + children moved together), so
+ancestor-scoped styling is preserved.
+
+Remaining for a follow-up: the effect/body-location component-specific classes (the
+effect list's `contentSelector` needs a paired `src/` edit, and much of the
+body-location SCSS is dead and better deleted than renamed) and the state-modifier
+normalization (`active`/`disabled` are JS/Foundry-toggled and need per-site care).

--- a/scss/components/_items.scss
+++ b/scss/components/_items.scss
@@ -1,7 +1,7 @@
 @use "../abstracts/mixins";
 @use "list";
 
-.items {
+.list-section {
     h2 {
         @include list.section-title(
             var(--sohl-color-text-primary),
@@ -22,10 +22,10 @@
         color: var(--sohl-color-text-muted);
     }
 
-    .items-list {
+    .list {
         @include list.scroll-body;
 
-        .items-header {
+        .list__header {
             @include list.header-row(
                 var(--sohl-color-bg-overlay-dark),
                 var(--sohl-color-border-subtle)
@@ -35,7 +35,7 @@
                 padding-right: 5px;
             }
 
-            .item-name {
+            .list__name {
                 color: var(--sohl-color-text-primary);
                 border-right: 1px solid var(--sohl-color-border-default);
 
@@ -63,7 +63,7 @@
             }
         }
 
-        .item-list {
+        .list__items {
             @include list.reset;
         }
 
@@ -148,18 +148,18 @@
             text-align: center;
         }
 
-        .item-controls {
+        .list__controls {
             @include list.controls(45px);
 
-            .item-control {
+            .list__control {
                 flex: 0 0 22px;
             }
         }
 
-        .item-controls-wide {
+        .list__controls--wide {
             @include list.controls(65px);
 
-            .item-control {
+            .list__control {
                 flex: 0 0 22px;
             }
         }
@@ -169,7 +169,7 @@
             padding: 0 2px;
             border-bottom: 1px solid var(--sohl-color-border-default);
 
-            .item-image {
+            .list__image {
                 flex: 0 0 30px;
                 background-size: 24px 24px;
                 background-repeat: no-repeat;

--- a/templates/actor/being/combat.hbs
+++ b/templates/actor/being/combat.hbs
@@ -33,58 +33,58 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <fieldset>
         <legend>Melee Weapons</legend>
         {{#each meleeWeapons as |entry|}}
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">{{entry.weapon.name}}</h3>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu" data-item-id="{{entry.weapon.id}}"><i class="sohl-ellipsis-vertical"></i></a>
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">{{entry.weapon.name}}</h3>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu" data-item-id="{{entry.weapon.id}}"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </header>
-            <ol class="item-list">
-                <li class="items-header flexrow">
-                    <h3 class="item-name">Strike Mode</h3>
-                    <div class="item-detail" data-tooltip="Heft">HFT</div>
-                    <div class="item-detail" data-tooltip="Reach">RCH</div>
-                    <div class="item-detail" data-tooltip="Spread">Spr</div>
-                    <div class="item-detail" data-tooltip="Impact">Impact</div>
-                    <div class="item-detail" data-tooltip="Attack ML">Atk</div>
-                    <div class="item-detail" data-tooltip="Block ML">Blk</div>
-                    <div class="item-detail" data-tooltip="Counterstrike ML">CX</div>
+            <ol class="list__items">
+                <li class="list__header flexrow">
+                    <h3 class="list__name">Strike Mode</h3>
+                    <div class="list__detail" data-tooltip="Heft">HFT</div>
+                    <div class="list__detail" data-tooltip="Reach">RCH</div>
+                    <div class="list__detail" data-tooltip="Spread">Spr</div>
+                    <div class="list__detail" data-tooltip="Impact">Impact</div>
+                    <div class="list__detail" data-tooltip="Attack ML">Atk</div>
+                    <div class="list__detail" data-tooltip="Block ML">Blk</div>
+                    <div class="list__detail" data-tooltip="Counterstrike ML">CX</div>
                 </li>
                 {{#each entry.strikeModes as |sm|}}
                 <li class="item flexrow" data-sm-id="{{sm.id}}" data-item-id="{{entry.weapon.id}}">
-                    <div class="item-name default-action flexrow">
+                    <div class="list__name default-action flexrow">
                         <h4 data-tooltip="{{sm.name}}">{{sm.name}}</h4>
                     </div>
-                    <div class="item-detail">{{sm.length.effective}}</div>
-                    <div class="item-detail">{{sm.reach.effective}}</div>
-                    <div class="item-detail">{{sm.spread.effective}}</div>
+                    <div class="list__detail">{{sm.length.effective}}</div>
+                    <div class="list__detail">{{sm.reach.effective}}</div>
+                    <div class="list__detail">{{sm.spread.effective}}</div>
                     {{#unless sm.impact.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeImpact" data-tooltip="Roll impact">
+                    <div class="list__detail rollable" data-action="rollStrikeModeImpact" data-tooltip="Roll impact">
                         {{sm.impact.label}}
                     </div>
                     {{else}}
-                    <div class="item-detail">
+                    <div class="list__detail">
                         <i class="sohl-xmark"></i>
                     </div>
                     {{/unless}}
                     {{#unless sm.attack.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="attack" data-tooltip="Roll attack (shift-click to skip dialog)">{{sm.attack.effective}}</div>
+                    <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="attack" data-tooltip="Roll attack (shift-click to skip dialog)">{{sm.attack.effective}}</div>
                     {{else}}
-                    <div class="item-detail"><i class="sohl-xmark"></i></div>
+                    <div class="list__detail"><i class="sohl-xmark"></i></div>
                     {{/unless}}
                     {{#unless sm.defense.block.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="block" data-tooltip="Roll block (shift-click to skip dialog)">{{sm.defense.block.effective}}</div>
+                    <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="block" data-tooltip="Roll block (shift-click to skip dialog)">{{sm.defense.block.effective}}</div>
                     {{else}}
-                    <div class="item-detail"><i class="sohl-xmark"></i></div>
+                    <div class="list__detail"><i class="sohl-xmark"></i></div>
                     {{/unless}}
                     {{#unless sm.defense.counterstrike.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="counterstrike" data-tooltip="Roll counterstrike (shift-click to skip dialog)">{{sm.defense.counterstrike.effective}}</div>
+                    <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="counterstrike" data-tooltip="Roll counterstrike (shift-click to skip dialog)">{{sm.defense.counterstrike.effective}}</div>
                     {{else}}
-                    <div class="item-detail"><i class="sohl-xmark"></i></div>
+                    <div class="list__detail"><i class="sohl-xmark"></i></div>
                     {{/unless}}
-                    <div class="item-controls">
-                        <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                    <div class="list__controls">
+                        <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                     </div>
                 </li>
                 {{/each}}
@@ -99,48 +99,48 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <fieldset>
         <legend>Ranged Weapons</legend>
         {{#each missileWeapons as |entry|}}
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">{{entry.weapon.name}}</h3>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu" data-item-id="{{entry.weapon.id}}"><i class="sohl-ellipsis-vertical"></i></a>
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">{{entry.weapon.name}}</h3>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu" data-item-id="{{entry.weapon.id}}"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </header>
-            <ol class="item-list">
-                <li class="items-header flexrow">
-                    <h3 class="item-name">Strike Mode</h3>
-                    <div class="item-detail" data-tooltip="Pull Strength">Pull</div>
-                    <div class="item-detail" data-tooltip="Draw Time">Draw</div>
-                    <div class="item-detail" data-tooltip="Base Range">BR</div>
-                    <div class="item-detail" data-tooltip="Max Volley Multiplier">MaxVM</div>
-                    <div class="item-detail" data-tooltip="Impact">Impact</div>
-                    <div class="item-detail" data-tooltip="Attack ML">Atk</div>
+            <ol class="list__items">
+                <li class="list__header flexrow">
+                    <h3 class="list__name">Strike Mode</h3>
+                    <div class="list__detail" data-tooltip="Pull Strength">Pull</div>
+                    <div class="list__detail" data-tooltip="Draw Time">Draw</div>
+                    <div class="list__detail" data-tooltip="Base Range">BR</div>
+                    <div class="list__detail" data-tooltip="Max Volley Multiplier">MaxVM</div>
+                    <div class="list__detail" data-tooltip="Impact">Impact</div>
+                    <div class="list__detail" data-tooltip="Attack ML">Atk</div>
                 </li>
                 {{#each entry.strikeModes as |sm|}}
                 <li class="item flexrow" data-sm-id="{{sm.id}}" data-item-id="{{entry.weapon.id}}">
-                    <div class="item-name default-action flexrow">
+                    <div class="list__name default-action flexrow">
                         <h4 data-tooltip="{{sm.name}}">{{sm.name}}</h4>
                     </div>
-                    <div class="item-detail">{{sm.draw.effective}}</div>
-                    <div class="item-detail">{{sm.draw.effective}}</div>
-                    <div class="item-detail">{{sm.baseRange.effective}}</div>
-                    <div class="item-detail">{{sm.maxVolleyMult}}</div>
+                    <div class="list__detail">{{sm.draw.effective}}</div>
+                    <div class="list__detail">{{sm.draw.effective}}</div>
+                    <div class="list__detail">{{sm.baseRange.effective}}</div>
+                    <div class="list__detail">{{sm.maxVolleyMult}}</div>
                     {{#unless sm.impact.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeImpact" data-tooltip="Roll impact">
+                    <div class="list__detail rollable" data-action="rollStrikeModeImpact" data-tooltip="Roll impact">
                         {{sm.impact.label}}
                     </div>
                     {{else}}
-                    <div class="item-detail">
+                    <div class="list__detail">
                         <i class="sohl-xmark"></i>
                     </div>
                     {{/unless}}
                     {{#unless sm.attack.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="attack" data-tooltip="Roll attack (shift-click to skip dialog)">{{sm.attack.effective}}</div>
+                    <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="attack" data-tooltip="Roll attack (shift-click to skip dialog)">{{sm.attack.effective}}</div>
                     {{else}}
-                    <div class="item-detail"><i class="sohl-xmark"></i></div>
+                    <div class="list__detail"><i class="sohl-xmark"></i></div>
                     {{/unless}}
-                    <div class="item-controls">
-                        <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                    <div class="list__controls">
+                        <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                     </div>
                 </li>
                 {{/each}}
@@ -155,61 +155,61 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <fieldset>
         <legend>Combat Techniques</legend>
         {{#each combatTechniques as |entry|}}
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">{{entry.item.name}}</h3>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu" data-item-id="{{entry.item.id}}"><i class="sohl-ellipsis-vertical"></i></a>
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">{{entry.item.name}}</h3>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu" data-item-id="{{entry.item.id}}"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </header>
-            <ol class="item-list">
-                <li class="items-header flexrow">
-                    <h3 class="item-name">Strike Mode</h3>
-                    <div class="item-detail" data-tooltip="Spread">Spr</div>
-                    <div class="item-detail" data-tooltip="Impact">Impact</div>
-                    <div class="item-detail" data-tooltip="Attack ML">Atk</div>
-                    <div class="item-detail" data-tooltip="Block ML">Blk</div>
-                    <div class="item-detail" data-tooltip="Counterstrike ML">CX</div>
+            <ol class="list__items">
+                <li class="list__header flexrow">
+                    <h3 class="list__name">Strike Mode</h3>
+                    <div class="list__detail" data-tooltip="Spread">Spr</div>
+                    <div class="list__detail" data-tooltip="Impact">Impact</div>
+                    <div class="list__detail" data-tooltip="Attack ML">Atk</div>
+                    <div class="list__detail" data-tooltip="Block ML">Blk</div>
+                    <div class="list__detail" data-tooltip="Counterstrike ML">CX</div>
                 </li>
                 {{#each entry.strikeModes as |sm|}}
                 <li class="item flexrow" data-sm-id="{{sm.id}}" data-item-id="{{entry.item.id}}">
-                    <div class="item-name default-action flexrow">
+                    <div class="list__name default-action flexrow">
                         <h4 data-tooltip="{{sm.name}}">{{sm.name}}</h4>
                     </div>
-                    <div class="item-detail">
+                    <div class="list__detail">
                         {{#if sm.isMelee}}{{sm.spread.effective}}{{/if}}
                     </div>
                     {{#unless sm.impact.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeImpact" data-tooltip="Roll impact">
+                    <div class="list__detail rollable" data-action="rollStrikeModeImpact" data-tooltip="Roll impact">
                         {{sm.impact.label}}
                     </div>
                     {{else}}
-                    <div class="item-detail">
+                    <div class="list__detail">
                         <i class="sohl-xmark"></i>
                     </div>
                     {{/unless}}
                     {{#unless sm.attack.disabled}}
-                    <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="attack" data-tooltip="Roll attack (shift-click to skip dialog)">{{sm.attack.effective}}</div>
+                    <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="attack" data-tooltip="Roll attack (shift-click to skip dialog)">{{sm.attack.effective}}</div>
                     {{else}}
-                    <div class="item-detail"><i class="sohl-xmark"></i></div>
+                    <div class="list__detail"><i class="sohl-xmark"></i></div>
                     {{/unless}}
                     {{#if sm.isMelee}}
                         {{#unless sm.defense.block.disabled}}
-                        <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="block" data-tooltip="Roll block (shift-click to skip dialog)">{{sm.defense.block.effective}}</div>
+                        <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="block" data-tooltip="Roll block (shift-click to skip dialog)">{{sm.defense.block.effective}}</div>
                         {{else}}
-                        <div class="item-detail"><i class="sohl-xmark"></i></div>
+                        <div class="list__detail"><i class="sohl-xmark"></i></div>
                         {{/unless}}
                         {{#unless sm.defense.counterstrike.disabled}}
-                        <div class="item-detail rollable" data-action="rollStrikeModeTest" data-test-kind="counterstrike" data-tooltip="Roll counterstrike (shift-click to skip dialog)">{{sm.defense.counterstrike.effective}}</div>
+                        <div class="list__detail rollable" data-action="rollStrikeModeTest" data-test-kind="counterstrike" data-tooltip="Roll counterstrike (shift-click to skip dialog)">{{sm.defense.counterstrike.effective}}</div>
                         {{else}}
-                        <div class="item-detail"><i class="sohl-xmark"></i></div>
+                        <div class="list__detail"><i class="sohl-xmark"></i></div>
                         {{/unless}}
                     {{else}}
-                        <div class="item-detail"></div>
-                        <div class="item-detail"></div>
+                        <div class="list__detail"></div>
+                        <div class="list__detail"></div>
                     {{/if}}
-                    <div class="item-controls">
-                        <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                    <div class="list__controls">
+                        <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                     </div>
                 </li>
                 {{/each}}
@@ -224,31 +224,31 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <fieldset>
         <legend>Anatomy</legend>
         {{#each bodyStructure.parts as |part|}}
-        <div class="items-list bodypart">
-            <header class="items-header flexrow">
+        <div class="list bodypart">
+            <header class="list__header flexrow">
                 <div class="body-drop"><i class="fas fa-chevron-right"></i></div>
-                <h3 class="item-name name">{{part.shortcode}}</h3>
-                <div class="item-detail">Wt: {{part.probWeight.effective}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <h3 class="list__name name">{{part.shortcode}}</h3>
+                <div class="list__detail">Wt: {{part.probWeight.effective}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </header>
-            <ol class="item-list bodylocations-list">
+            <ol class="list__items bodylocations-list">
                 {{#each part.locations as |loc|}}
                 <li class="item bodylocation flexrow" data-part-index="{{part.index}}" data-loc-index="{{loc.index}}">
                     <div class="body-drop"></div>
                     <div class="body-drop"></div>
-                    <div class="item-name default-action flexrow">
+                    <div class="list__name default-action flexrow">
                         <h4>{{loc.shortcode}}</h4>
                     </div>
-                    <div class="item-detail" data-tooltip="Probability">{{loc.probWeight.effective}}</div>
-                    <div class="item-detail" data-tooltip="Blunt">B:{{loc.protectionBase.blunt.effective}}</div>
-                    <div class="item-detail" data-tooltip="Edged">E:{{loc.protectionBase.edged.effective}}</div>
-                    <div class="item-detail" data-tooltip="Piercing">P:{{loc.protectionBase.piercing.effective}}</div>
-                    <div class="item-detail" data-tooltip="Fire">F:{{loc.protectionBase.fire.effective}}</div>
-                    <div class="item-detail" data-tooltip="Shock">{{loc.shockValue.effective}}</div>
-                    <div class="item-controls">
-                        <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                    <div class="list__detail" data-tooltip="Probability">{{loc.probWeight.effective}}</div>
+                    <div class="list__detail" data-tooltip="Blunt">B:{{loc.protectionBase.blunt.effective}}</div>
+                    <div class="list__detail" data-tooltip="Edged">E:{{loc.protectionBase.edged.effective}}</div>
+                    <div class="list__detail" data-tooltip="Piercing">P:{{loc.protectionBase.piercing.effective}}</div>
+                    <div class="list__detail" data-tooltip="Fire">F:{{loc.protectionBase.fire.effective}}</div>
+                    <div class="list__detail" data-tooltip="Shock">{{loc.shockValue.effective}}</div>
+                    <div class="list__controls">
+                        <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                     </div>
                 </li>
                 {{/each}}

--- a/templates/actor/being/mysteries.hbs
+++ b/templates/actor/being/mysteries.hbs
@@ -16,36 +16,36 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#each mysteryGroups as |mysteries groupName|}}
     <fieldset>
         <legend>{{@key}} Mysteries</legend>
-        <ol class="item-list">
-            <li class="items-header flexrow">
-                <h3 class="item-name">Mystery</h3>
-                <div class="item-detail">Bonus</div>
-                <div class="item-detail">Charges</div>
-                <div class="item-detail">Notes</div>
+        <ol class="list__items">
+            <li class="list__header flexrow">
+                <h3 class="list__name">Mystery</h3>
+                <div class="list__detail">Bonus</div>
+                <div class="list__detail">Charges</div>
+                <div class="list__detail">Notes</div>
             </li>
             {{#each mysteries as |mystery|}}
             <li class="item flexrow" data-item-id="{{mystery.id}}" data-item-name="{{mystery.name}}">
-                <div class="item-name default-action flexrow">
-                    <div class="item-image" style="background-image: url('{{mystery.img}}')"></div>
+                <div class="list__name default-action flexrow">
+                    <div class="list__image" style="background-image: url('{{mystery.img}}')"></div>
                     <h4 data-tooltip="{{mystery.name}}">{{mystery.name}}</h4>
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if mystery.logic.level.disabled}}
                     <i class="sohl-xmark"></i>
                     {{else}}
                     {{numberFormat mystery.logic.level.effective sign=true}}
                     {{/if}}
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if mystery.logic.charges.value.disabled}}
                     <i class="sohl-xmark"></i>
                     {{else}}
                     {{mystery.logic.charges.value.effective}}{{#if (gt mystery.logic.charges.max.effective 0)}}/{{numberFormat mystery.logic.charges.max.effective}}{{/if}}
                     {{/if}}
                 </div>
-                <div class="item-detail">{{mystery.system.notes}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__detail">{{mystery.system.notes}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}
@@ -57,36 +57,36 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#each abilityGroups as |abilities groupName|}}
     <fieldset>
         <legend>{{@key}} Mystical Abilities</legend>
-        <ol class="item-list">
-            <li class="items-header flexrow">
-                <h3 class="item-name">Ability</h3>
-                <div class="item-detail">ML</div>
-                <div class="item-detail">Charges</div>
-                <div class="item-detail">Notes</div>
+        <ol class="list__items">
+            <li class="list__header flexrow">
+                <h3 class="list__name">Ability</h3>
+                <div class="list__detail">ML</div>
+                <div class="list__detail">Charges</div>
+                <div class="list__detail">Notes</div>
             </li>
             {{#each abilities as |ability|}}
             <li class="item flexrow" data-item-id="{{ability.id}}" data-item-name="{{ability.name}}">
-                <div class="item-name default-action flexrow">
-                    <div class="item-image" style="background-image: url('{{ability.img}}')"></div>
+                <div class="list__name default-action flexrow">
+                    <div class="list__image" style="background-image: url('{{ability.img}}')"></div>
                     <h4 data-tooltip="{{ability.name}}">{{ability.name}}</h4>
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if ability.logic.level.disabled}}
                     <i class="sohl-xmark"></i>
                     {{else}}
                     {{ability.logic.level.effective}}
                     {{/if}}
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if ability.logic.charges.value.disabled}}
                     <i class="sohl-xmark"></i>
                     {{else}}
                     {{ability.logic.charges.value.effective}}{{#if (gt ability.logic.charges.max.effective 0)}}/{{numberFormat ability.logic.charges.max.effective}}{{/if}}
                     {{/if}}
                 </div>
-                <div class="item-detail">{{ability.system.notes}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__detail">{{ability.system.notes}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}

--- a/templates/actor/being/profile.hbs
+++ b/templates/actor/being/profile.hbs
@@ -42,17 +42,17 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#each traitGroups as |traits groupName|}}
     <fieldset>
         <legend>{{@key}}</legend>
-        <ol class="item-list traits">
+        <ol class="list__items traits">
             {{#each traits as |trait|}}
             <li class="item flexrow" data-item-id="{{trait.id}}" data-item-name="{{trait.name}}">
-                <div class="item-name flexrow">
+                <div class="list__name flexrow">
                     <h4>{{trait.name}}</h4>
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if trait.system.isNumeric}}{{trait.system.masteryLevelBase}}{{else}}{{trait.system.textValue}}{{/if}}
                 </div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}
@@ -64,14 +64,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#if affiliations.length}}
     <fieldset>
         <legend>Affiliations</legend>
-        <ol class="item-list">
+        <ol class="list__items">
             {{#each affiliations as |aff|}}
             <li class="item flexrow" data-item-id="{{aff.id}}">
-                <div class="item-name"><h4>{{aff.name}}</h4></div>
-                <div class="item-detail">{{aff.system.society}}</div>
-                <div class="item-detail">{{aff.system.title}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__name"><h4>{{aff.name}}</h4></div>
+                <div class="list__detail">{{aff.system.society}}</div>
+                <div class="list__detail">{{aff.system.title}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}
@@ -83,11 +83,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#if movement.length}}
     <fieldset>
         <legend>{{localize "SOHL.Being.movement.legend"}}</legend>
-        <ol class="item-list movement">
+        <ol class="list__items movement">
             {{#each movement as |row|}}
             <li class="item flexrow" data-medium="{{row.medium}}">
-                <div class="item-name"><h4>{{localize row.label}}</h4></div>
-                <div class="item-detail">{{row.value}} {{localize "SOHL.Being.movement.unit"}}</div>
+                <div class="list__name"><h4>{{localize row.label}}</h4></div>
+                <div class="list__detail">{{row.value}} {{localize "SOHL.Being.movement.unit"}}</div>
             </li>
             {{/each}}
         </ol>

--- a/templates/actor/being/skills.hbs
+++ b/templates/actor/being/skills.hbs
@@ -32,21 +32,21 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#each skillGroups as |skills groupName|}}
     <fieldset>
         <legend>{{@key}}</legend>
-        <ol class="item-list skills-list">
-            <li class="items-header flexrow">
-                <h3 class="item-name">Skill</h3>
-                <div class="item-detail">SB</div>
-                <div class="item-detail">ML</div>
+        <ol class="list__items skills-list">
+            <li class="list__header flexrow">
+                <h3 class="list__name">Skill</h3>
+                <div class="list__detail">SB</div>
+                <div class="list__detail">ML</div>
             </li>
             {{#each skills as |skill|}}
             <li class="item flexrow" data-item-id="{{skill.id}}" data-item-name="{{skill.name}}">
-                <div class="item-name default-action flexrow">
+                <div class="list__name default-action flexrow">
                     <h4>{{skill.name}}</h4>
                 </div>
-                <div class="item-detail">{{skill.system.skillBaseFormula}}</div>
-                <div class="item-detail">{{skill.system.masteryLevelBase}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__detail">{{skill.system.skillBaseFormula}}</div>
+                <div class="list__detail">{{skill.system.masteryLevelBase}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}

--- a/templates/actor/being/trauma.hbs
+++ b/templates/actor/being/trauma.hbs
@@ -24,57 +24,57 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <legend>
             Injuries
             {{#if editable}}
-            <a class="item-control" data-action="addInjury" data-tooltip="Add Injury">
+            <a class="list__control" data-action="addInjury" data-tooltip="Add Injury">
                 <i class="sohl-plus"></i>
             </a>
             {{/if}}
         </legend>
-        <ol class="item-list">
-            <li class="items-header flexrow">
-                <h3 class="item-name">Injury</h3>
-                <div class="item-detail" data-tooltip="Injury Level">Sev</div>
-                <div class="item-detail" data-tooltip="Healing Rate">HR</div>
-                <div class="item-detail">Aspect</div>
-                <div class="item-detail" data-tooltip="Treated">Trt</div>
-                <div class="item-detail" data-tooltip="Bleeding">Bld</div>
+        <ol class="list__items">
+            <li class="list__header flexrow">
+                <h3 class="list__name">Injury</h3>
+                <div class="list__detail" data-tooltip="Injury Level">Sev</div>
+                <div class="list__detail" data-tooltip="Healing Rate">HR</div>
+                <div class="list__detail">Aspect</div>
+                <div class="list__detail" data-tooltip="Treated">Trt</div>
+                <div class="list__detail" data-tooltip="Bleeding">Bld</div>
             </li>
             {{#each traumas as |injury|}}
             <li class="item flexrow" data-item-id="{{injury.id}}" data-item-name="{{injury.name}}">
-                <div class="item-name default-action flexrow">
-                    <div class="item-image" style="background-image: url('{{injury.img}}')"></div>
+                <div class="list__name default-action flexrow">
+                    <div class="list__image" style="background-image: url('{{injury.img}}')"></div>
                     <h4 data-tooltip="{{injury.name}}">{{injury.name}}</h4>
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if (lte injury.logic.level.effective 0)}}
                     <i class="sohl-heart-plus"></i>
                     {{else}}
                     {{injury.logic.level.effective}}
                     {{/if}}
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if injury.logic.healingRate.disabled}}
                     <i class="sohl-xmark"></i>
                     {{else}}
                     {{injury.logic.healingRate.effective}}
                     {{/if}}
                 </div>
-                <div class="item-detail">{{injury.system.aspect}}</div>
-                <div class="item-detail">
+                <div class="list__detail">{{injury.system.aspect}}</div>
+                <div class="list__detail">
                     {{#if injury.system.isTreated}}
                     <i class="sohl-check"></i>
                     {{else}}
                     <i class="sohl-xmark"></i>
                     {{/if}}
                 </div>
-                <div class="item-detail">
+                <div class="list__detail">
                     {{#if injury.system.isBleeding}}
                     <i class="sohl-drop danger"></i>
                     {{else}}
                     <i class="sohl-xmark"></i>
                     {{/if}}
                 </div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}
@@ -85,28 +85,28 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{#each afflictionGroups as |afflictions groupName|}}
     <fieldset>
         <legend>{{@key}} Afflictions</legend>
-        <ol class="item-list">
-            <li class="items-header flexrow">
-                <h3 class="item-name">Affliction</h3>
-                <div class="item-detail" data-tooltip="Level">Level</div>
-                <div class="item-detail" data-tooltip="Healing Rate">HR</div>
+        <ol class="list__items">
+            <li class="list__header flexrow">
+                <h3 class="list__name">Affliction</h3>
+                <div class="list__detail" data-tooltip="Level">Level</div>
+                <div class="list__detail" data-tooltip="Healing Rate">HR</div>
             </li>
             {{#each afflictions as |aff|}}
             <li class="item flexrow" data-item-id="{{aff.id}}" data-item-name="{{aff.name}}">
-                <div class="item-name default-action flexrow">
-                    <div class="item-image" style="background-image: url('{{aff.img}}')"></div>
+                <div class="list__name default-action flexrow">
+                    <div class="list__image" style="background-image: url('{{aff.img}}')"></div>
                     <h4 data-tooltip="{{aff.name}}">{{aff.name}}</h4>
                 </div>
-                <div class="item-detail">{{aff.logic.level.effective}}</div>
-                <div class="item-detail">
+                <div class="list__detail">{{aff.logic.level.effective}}</div>
+                <div class="list__detail">
                     {{#if aff.logic.healingRate.disabled}}
                     <i class="sohl-xmark"></i>
                     {{else}}
                     {{aff.logic.healingRate.effective}}
                     {{/if}}
                 </div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}

--- a/templates/actor/cohort/members.hbs
+++ b/templates/actor/cohort/members.hbs
@@ -42,21 +42,21 @@ SPDX-License-Identifier: GPL-3.0-or-later
     {{!-- Member List --}}
     <fieldset>
         <legend>Members</legend>
-        <ol class="item-list">
-            <li class="items-header flexrow">
-                <h3 class="item-name">Name</h3>
-                <div class="item-detail">Shortcode</div>
-                <div class="item-detail">Role</div>
+        <ol class="list__items">
+            <li class="list__header flexrow">
+                <h3 class="list__name">Name</h3>
+                <div class="list__detail">Shortcode</div>
+                <div class="list__detail">Role</div>
             </li>
             {{#each members as |member|}}
             <li class="item flexrow" data-item-id="{{member.id}}" data-item-name="{{member.name}}">
-                <div class="item-name default-action flexrow">
+                <div class="list__name default-action flexrow">
                     <h4 data-tooltip="{{member.name}}">{{member.name}}</h4>
                 </div>
-                <div class="item-detail">{{member.shortcode}}</div>
-                <div class="item-detail">{{member.role}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
+                <div class="list__detail">{{member.shortcode}}</div>
+                <div class="list__detail">{{member.role}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu"><i class="sohl-ellipsis-vertical"></i></a>
                 </div>
             </li>
             {{/each}}

--- a/templates/actor/parts/actions.hbs
+++ b/templates/actor/parts/actions.hbs
@@ -16,20 +16,20 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <input class="search-criteria" type="search" name="search-actions" value=""
             aria-label="Search Actions" placeholder="Search Actions" autocomplete="off" />
     </div>
-    <ol class="item-list actions-list">
-        <li class="items-header flexrow">
-            <h3 class="item-name">Action</h3>
-            <div class="item-detail">Group</div>
+    <ol class="list__items actions-list">
+        <li class="list__header flexrow">
+            <h3 class="list__name">Action</h3>
+            <div class="list__detail">Group</div>
         </li>
         {{#each actions as |action|}}
         <li class="item flexrow" data-item-id="{{action.item.id}}">
-            <div class="item-name flexrow">
+            <div class="list__name flexrow">
                 <i class="{{action.data.iconFAClass}}"></i>
                 <h4>{{action.data.title}}</h4>
             </div>
-            <div class="item-detail">{{action.data.group}}</div>
-            <div class="item-controls">
-                <a class="item-control item-contextmenu" title="Menu">
+            <div class="list__detail">{{action.data.group}}</div>
+            <div class="list__controls">
+                <a class="list__control item-contextmenu" title="Menu">
                     <i class="sohl-ellipsis-vertical"></i>
                 </a>
             </div>

--- a/templates/actor/parts/gear.hbs
+++ b/templates/actor/parts/gear.hbs
@@ -24,33 +24,33 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
     {{!-- On Body (ungrouped gear) --}}
     {{#if onBodyItems.length}}
-    <div class="items-list gear-list">
-        <header class="items-header flexrow">
-            <h3 class="item-name">On Body</h3>
-            <div class="item-detail">Type</div>
-            <div class="item-detail">Qty</div>
-            <div class="item-detail">Wt</div>
+    <div class="list gear-list">
+        <header class="list__header flexrow">
+            <h3 class="list__name">On Body</h3>
+            <div class="list__detail">Type</div>
+            <div class="list__detail">Qty</div>
+            <div class="list__detail">Wt</div>
         </header>
-        <ol class="item-list">
+        <ol class="list__items">
             {{#each onBodyItems as |item|}}
             <li class="item flexrow" data-item-id="{{item.id}}" data-uuid="{{item.uuid}}">
-                <div class="item-name flexrow">
-                    <div class="item-image" style="background-image: url('{{item.img}}')"></div>
+                <div class="list__name flexrow">
+                    <div class="list__image" style="background-image: url('{{item.img}}')"></div>
                     <h4>{{item.name}}</h4>
                 </div>
-                <div class="item-detail">{{item.type}}</div>
-                <div class="item-detail">{{item.system.quantity}}</div>
-                <div class="item-detail">{{item.system.weightBase}}</div>
-                <div class="item-controls">
+                <div class="list__detail">{{item.type}}</div>
+                <div class="list__detail">{{item.system.quantity}}</div>
+                <div class="list__detail">{{item.system.weightBase}}</div>
+                <div class="list__controls">
                     {{#if (eq item.type "armorgear")}}
-                    <a class="item-control item-worn" title="Worn">
+                    <a class="list__control item-worn" title="Worn">
                         <i class="sohl-chest-armor {{#unless item.system.isEquipped}}disabled{{/unless}}"></i>
                     </a>
                     {{/if}}
-                    <a class="item-control item-carried" title="Carried">
+                    <a class="list__control item-carried" title="Carried">
                         <i class="sohl-sack {{#unless item.system.isCarried}}disabled{{/unless}}"></i>
                     </a>
-                    <a class="item-control item-contextmenu" title="Menu">
+                    <a class="list__control item-contextmenu" title="Menu">
                         <i class="sohl-ellipsis-vertical"></i>
                     </a>
                 </div>
@@ -62,25 +62,25 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
     {{!-- Containers --}}
     {{#each containers as |entry|}}
-    <div class="items-list gear-list" data-container-id="{{entry.container.id}}">
-        <header class="items-header flexrow">
-            <h3 class="item-name">{{entry.container.name}}</h3>
-            <div class="item-detail">Type</div>
-            <div class="item-detail">Qty</div>
-            <div class="item-detail">Wt</div>
+    <div class="list gear-list" data-container-id="{{entry.container.id}}">
+        <header class="list__header flexrow">
+            <h3 class="list__name">{{entry.container.name}}</h3>
+            <div class="list__detail">Type</div>
+            <div class="list__detail">Qty</div>
+            <div class="list__detail">Wt</div>
         </header>
-        <ol class="item-list">
+        <ol class="list__items">
             {{#each entry.items as |item|}}
             <li class="item flexrow" data-item-id="{{item.id}}" data-uuid="{{item.uuid}}">
-                <div class="item-name flexrow">
-                    <div class="item-image" style="background-image: url('{{item.img}}')"></div>
+                <div class="list__name flexrow">
+                    <div class="list__image" style="background-image: url('{{item.img}}')"></div>
                     <h4>{{item.name}}</h4>
                 </div>
-                <div class="item-detail">{{item.type}}</div>
-                <div class="item-detail">{{item.system.quantity}}</div>
-                <div class="item-detail">{{item.system.weightBase}}</div>
-                <div class="item-controls">
-                    <a class="item-control item-contextmenu" title="Menu">
+                <div class="list__detail">{{item.type}}</div>
+                <div class="list__detail">{{item.system.quantity}}</div>
+                <div class="list__detail">{{item.system.weightBase}}</div>
+                <div class="list__controls">
+                    <a class="list__control item-contextmenu" title="Menu">
                         <i class="sohl-ellipsis-vertical"></i>
                     </a>
                 </div>

--- a/templates/item/attribute-properties.hbs
+++ b/templates/item/attribute-properties.hbs
@@ -18,40 +18,40 @@ SPDX-License-Identifier: GPL-3.0-or-later
         {{formField fields.initDiceFormula rootId="attribute-initdice" classes="text-field" stacked=true value=system.initDiceFormula}}
     </div>
 
-    <div class="items">
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">Value Descriptors</h3>
+    <div class="list-section">
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">Value Descriptors</h3>
                 <div class="detail ele">Max Value</div>
             </header>
-            <ol class="items-list">
+            <ol class="list">
                 {{#each valueDesc}}
                 <li class="item flexrow">
-                    <div class="item-name name">{{this.label}}</div>
+                    <div class="list__name name">{{this.label}}</div>
                     <div class="detail ele">{{this.maxValue}}</div>
                 </li>
                 {{else}}
                 <li class="item flexrow">
-                    <div class="item-name name">—</div>
+                    <div class="list__name name">—</div>
                 </li>
                 {{/each}}
             </ol>
         </div>
     </div>
 
-    <div class="items">
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">Impaired By Roles</h3>
+    <div class="list-section">
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">Impaired By Roles</h3>
             </header>
-            <ol class="items-list">
+            <ol class="list">
                 {{#each impairedByRoles}}
                 <li class="item flexrow">
-                    <div class="item-name name">{{this}}</div>
+                    <div class="list__name name">{{this}}</div>
                 </li>
                 {{else}}
                 <li class="item flexrow">
-                    <div class="item-name name">—</div>
+                    <div class="list__name name">—</div>
                 </li>
                 {{/each}}
             </ol>

--- a/templates/item/parts/actions.hbs
+++ b/templates/item/parts/actions.hbs
@@ -12,20 +12,20 @@ SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
 <section class="tab actions" data-tab="actions">
-    <ol class="item-list actions-list">
-        <li class="items-header flexrow">
-            <h3 class="item-name">{{localize "SOHL.Action.FIELDS.title.label"}}</h3>
+    <ol class="list__items actions-list">
+        <li class="list__header flexrow">
+            <h3 class="list__name">{{localize "SOHL.Action.FIELDS.title.label"}}</h3>
             <div class="item-type">{{localize "SOHL.Action.FIELDS.group.label"}}</div>
         </li>
         {{#each actions as |action|}}
         <li class="item flexrow" data-item-id="{{action.item.id}}">
-            <div class="item-name flexrow">
+            <div class="list__name flexrow">
                 <i class="{{action.data.iconFAClass}}"></i>
                 <h4>{{action.data.title}}</h4>
             </div>
             <div class="item-type">{{action.data.group}}</div>
-            <div class="item-controls">
-                <a class="item-control item-contextmenu" title="Menu">
+            <div class="list__controls">
+                <a class="list__control item-contextmenu" title="Menu">
                     <i class="sohl-ellipsis-vertical"></i>
                 </a>
             </div>

--- a/templates/item/parts/header.hbs
+++ b/templates/item/parts/header.hbs
@@ -14,7 +14,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 <header class="sheet-header flexrow">
     <img class="item-img" src="{{itemImg}}" data-edit="img" alt="{{itemName}}" />
     <div class="sheet-header__details">
-        <h1 class="item-name">
+        <h1 class="list__name">
             <input name="name" type="text" value="{{itemName}}" placeholder="{{localize 'Name'}}" />
         </h1>
         <div class="item-subtitle">

--- a/templates/item/trait-properties.hbs
+++ b/templates/item/trait-properties.hbs
@@ -39,22 +39,22 @@ SPDX-License-Identifier: GPL-3.0-or-later
         {{/if}}
     </div>
 
-    <div class="items">
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">Value Desc</h3>
+    <div class="list-section">
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">Value Desc</h3>
                 <div class="detail ele">Max</div>
-                <div class="item-controls">
-                    <a class="item-control add-array-item" data-array="system.aim" data-object-type="ValueDesc"
+                <div class="list__controls">
+                    <a class="list__control add-array-item" data-array="system.aim" data-object-type="ValueDesc"
                         data-title="Add Value Description"><i class="sohl-plus"></i> Add</a>
                 </div>
             </header>
-            <ol class="items-list">
+            <ol class="list">
                 {{#each idata.aim}}
                 <li class="item flexrow">
-                    <div class="item-name name">{{label}}</div>
+                    <div class="list__name name">{{label}}</div>
                     <div class="detail ele">{{maxValue}}</div>
-                    <div class="item-controls">
+                    <div class="list__controls">
                         <a class="delete-array-item" data-array="system.aim" data-index="{{@index}}"
                             title="Delete Value Description"><i class="sohl-trash"></i></a>
                     </div>
@@ -64,22 +64,22 @@ SPDX-License-Identifier: GPL-3.0-or-later
         </div>
     </div>
 
-    <div class="items">
-        <div class="items-list">
-            <header class="items-header flexrow">
-                <h3 class="item-name name">Choice Label</h3>
+    <div class="list-section">
+        <div class="list">
+            <header class="list__header flexrow">
+                <h3 class="list__name name">Choice Label</h3>
                 <div class="detail notes">Key</div>
-                <div class="item-controls">
-                    <a class="item-control add-object-key" data-object="system.choices"
+                <div class="list__controls">
+                    <a class="list__control add-object-key" data-object="system.choices"
                         data-title="Add Choice"><i class="sohl-plus"></i> Add</a>
                 </div>
             </header>
-            <ol class="items-list">
+            <ol class="list">
                 {{#each idata.choices}}
                 <li class="item flexrow">
-                    <div class="item-name name" title="{{this}}">{{this}}</div>
+                    <div class="list__name name" title="{{this}}">{{this}}</div>
                     <div class="detail notes" title="{{@key}}">{{@key}}</div>
-                    <div class="item-controls">
+                    <div class="list__controls">
                         <a class="delete-object-key" data-object="system.choices" data-key="{{@key}}"
                             title="Delete Choice"><i class="sohl-trash"></i></a>
                     </div>


### PR DESCRIPTION
Part 2 of #94 (BEM naming), continuing from the header/facade slice (#101, merged). Per your "do it all" — this lands the **shared list scaffolding**, the highest-impact piece. **Does not close #94** (remaining work below).

## What

Audited the list cluster's JS coupling first (this is the part that fails *invisibly*):
- `_displayFilteredResults` (`SohlActor.ts:1059`) does `querySelectorAll(".item")` → the `.item` row class is load-bearing for **all 8 search filters**.
- 8 `SearchFilter` `contentSelector`s are JS strings; `.item-contextmenu` / `.default-action` are event hooks.

So I renamed the **CSS-only** shared scaffolding (verified 0 `src/` references each — `item-detail` 107×, `item-name` 45×, `item-control` 25×, `item-controls` 24×, `items-header` 21×, `item-list` 17×, `items-list` 14×, `item-image` 6×) into one `list` BEM block, and **kept everything JS-coupled**:

| Old | New |
| --- | --- |
| `items` | `list-section` |
| `items-list` | `list` |
| `item-list` | `list__items` |
| `items-header` | `list__header` |
| `item-name` | `list__name` |
| `item-detail` | `list__detail` |
| `item-controls` / `item-controls-wide` | `list__controls` / `list__controls--wide` |
| `item-control` | `list__control` |
| `item-image` | `list__image` |

**Kept (JS-coupled):** `.item`, `.item-contextmenu`, `.default-action`, the 8 `contentSelector` classes. **Kept (safety):** generic leaf columns (`.name`, `.detail`, …, scoped under their block), Foundry classes (`flexrow`), `data-*`/`data-action`/`lang` keys.

13 files (12 templates + `_items.scss`).

## Verification

- Template class lists rewritten **only inside `class="…"`** (a perl pass scoped to class attributes), so handlebars expressions and `data-*` are untouched.
- **Zero orphaned old tokens** remain in `scss/` or `templates/` (greps clean).
- `.item` query in `_displayFilteredResults` confirmed intact; `.item-contextmenu` present in 9 templates.
- The rename is **consistent** (wrapper `items`→`list-section` and its children moved together), so ancestor-scoped styling relationships are preserved.
- `npm run build` (64 tests), `npm run build:css`, `npm run docs` (0 errors) — all pass.

