### PR TITLE
cleanup: group intrinsic actions and lifecycle methods into labeled sections

### DIFF
--- a/src/core/SohlLogic.ts
+++ b/src/core/SohlLogic.ts
@@ -302,6 +302,10 @@ export abstract class SohlLogic<
         return entries;
     }
 
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
     /**
      * Intrinsic action performed after finalize lifecycle stage.
      * This is intended for modules to hook into (or ActionItems to override)
@@ -313,13 +317,16 @@ export abstract class SohlLogic<
         // No-op by default
     }
 
-    /*--------------------------------------
-     * Phase-batched lifecycle methods
-     *
-     * Called by SohlActor.prepareEmbeddedData() in three barrier-separated
-     * passes across ALL items, NOT per-item like Foundry's default.
-     * See the class-level JSDoc and docs/concepts/lifecycle-model.md.
-     *--------------------------------------*/
+    /* --------------------------------------------- */
+    /* Common Lifecycle Actions                      */
+    /* --------------------------------------------- */
+
+    /*
+     * Phase-batched lifecycle methods, called by
+     * SohlActor.prepareEmbeddedData() in three barrier-separated passes across
+     * ALL items, NOT per-item like Foundry's default. See the class-level JSDoc
+     * and docs/concepts/lifecycle-model.md.
+     */
 
     /**
      * Set up base state from persisted data: create ValueModifiers, set base

--- a/src/document/actor/logic/BeingLogic.ts
+++ b/src/document/actor/logic/BeingLogic.ts
@@ -245,6 +245,10 @@ export class BeingLogic<
         );
     }
 
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
     /**
      * Apply the impact of an attack or effect to this being, calculating the resulting
      * location and damage. If armor or other defenses are unable to fully mitigate the impact,

--- a/src/document/actor/logic/SohlActorBaseLogic.ts
+++ b/src/document/actor/logic/SohlActorBaseLogic.ts
@@ -98,13 +98,6 @@ export interface SohlActorData<
 export class SohlActorBaseLogic<
     TData extends SohlActorData = SohlActorData,
 > extends SohlLogic<TData> {
-    /** Initialize-phase hook; base actor logic does nothing. */
-    override initialize(): void {}
-    /** Evaluate-phase hook; base actor logic does nothing. */
-    override evaluate(): void {}
-    /** Finalize-phase hook; base actor logic does nothing. */
-    override finalize(): void {}
-
     /**
      * Find an embedded item's logic by its `shortcode` and item kind.
      *
@@ -173,4 +166,15 @@ export class SohlActorBaseLogic<
     get hasPlayerOwner(): boolean {
         return this.data.hasPlayerOwner;
     }
+
+    /* --------------------------------------------- */
+    /* Common Lifecycle Actions                      */
+    /* --------------------------------------------- */
+
+    /** Initialize-phase hook; base actor logic does nothing. */
+    override initialize(): void {}
+    /** Evaluate-phase hook; base actor logic does nothing. */
+    override evaluate(): void {}
+    /** Finalize-phase hook; base actor logic does nothing. */
+    override finalize(): void {}
 }

--- a/src/document/combatant/logic/CombatantLogic.ts
+++ b/src/document/combatant/logic/CombatantLogic.ts
@@ -104,13 +104,6 @@ export interface CombatantData extends SohlLogicData<SohlCombatant> {
 export class CombatantLogic<
     TData extends CombatantData = CombatantData,
 > extends SohlLogic<TData> {
-    /** Initialize-phase hook; base combatant logic does nothing. */
-    override initialize(): void {}
-    /** Evaluate-phase hook; base combatant logic does nothing. */
-    override evaluate(): void {}
-    /** Finalize-phase hook; base combatant logic does nothing. */
-    override finalize(): void {}
-
     /** The strike mode last used to attack, or `null` (combat-scoped). */
     get lastAttackMode(): StrikeModeRef | null {
         return this.data.lastAttackMode;
@@ -259,6 +252,10 @@ export class CombatantLogic<
         const c = this.combatant;
         return c ? combatantSpacesMoved(c, this.data.startLocation) : 0;
     }
+
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
 
     // --- Automated combat start (attacker side) ------------------------------
 
@@ -781,6 +778,17 @@ export class CombatantLogic<
             },
         ];
     }
+
+    /* --------------------------------------------- */
+    /* Common Lifecycle Actions                      */
+    /* --------------------------------------------- */
+
+    /** Initialize-phase hook; base combatant logic does nothing. */
+    override initialize(): void {}
+    /** Evaluate-phase hook; base combatant logic does nothing. */
+    override evaluate(): void {}
+    /** Finalize-phase hook; base combatant logic does nothing. */
+    override finalize(): void {}
 }
 
 /* --------------------------------------------------------------------------

--- a/src/document/item/logic/AfflictionLogic.ts
+++ b/src/document/item/logic/AfflictionLogic.ts
@@ -228,6 +228,10 @@ export class AfflictionLogic<
         return true;
     }
 
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
     /**
      * Attempt to transmit this affliction from its bearer to another actor.
      *

--- a/src/document/item/logic/CombatTechniqueLogic.ts
+++ b/src/document/item/logic/CombatTechniqueLogic.ts
@@ -52,7 +52,7 @@ export class CombatTechniqueLogic<
     strikeMode!: StrikeModeBase;
 
     /* --------------------------------------------- */
-    /* Combat Intrinsic Actions                            */
+    /* Intrinsic Actions                             */
     /* --------------------------------------------- */
 
     /**

--- a/src/document/item/logic/GearLogic.ts
+++ b/src/document/item/logic/GearLogic.ts
@@ -75,62 +75,6 @@ export abstract class GearLogic<
      */
     sharedWithCohorts!: SohlActor[];
 
-    /**
-     * Define and return all intrinsic actions for this logic type.
-     * @returns The base item actions plus the gear carried/not-carried actions.
-     */
-    static override defineIntrinsicActions(): Partial<SohlAction.Data>[] {
-        return [
-            ...SohlItemBaseLogic.defineIntrinsicActions(),
-            {
-                shortcode: "setCarried",
-                subType: ACTION_SUBTYPE.INTRINSIC,
-                title: "SOHL.Gear.Action.setCarried",
-                scope: SOHL_ACTION_SCOPE.SELF,
-                iconFAClass: "sohl-round-star-filled",
-                executor: "setCarried",
-                visible: "true",
-                group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
-            },
-            {
-                shortcode: "setNotCarried",
-                subType: ACTION_SUBTYPE.INTRINSIC,
-                title: "SOHL.Gear.Action.setNotCarried",
-                scope: SOHL_ACTION_SCOPE.SELF,
-                iconFAClass: "sohl-round-star-unfilled",
-                executor: "setNotCarried",
-                visible: "true",
-                group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
-            },
-        ];
-    }
-
-    /**
-     * Marks this gear as carried on the character's person.
-     *
-     * Intrinsic-action executor for the `setCarried` action.
-     *
-     * @param _context - The action context (unused).
-     * @returns Resolves once the item update completes.
-     */
-    async setCarried(_context: SohlActionContext): Promise<void> {
-        const updateData: PlainObject = { "system.isCarried": true };
-        await this.data.update(updateData);
-    }
-
-    /**
-     * Marks this gear as not carried (stowed somewhere off-person).
-     *
-     * Intrinsic-action executor for the `setNotCarried` action.
-     *
-     * @param _context - The action context (unused).
-     * @returns Resolves once the item update completes.
-     */
-    async setNotCarried(_context: SohlActionContext): Promise<void> {
-        const updateData: PlainObject = { "system.isCarried": false };
-        await this.data.update(updateData);
-    }
-
     /* --------------------------------------------- */
     /* Array update helpers                          */
     /* --------------------------------------------- */
@@ -159,6 +103,66 @@ export abstract class GearLogic<
                 (id) => id !== cohortId,
             ),
         };
+    }
+
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
+    /**
+     * Marks this gear as carried on the character's person.
+     *
+     * Intrinsic-action executor for the `setCarried` action.
+     *
+     * @param _context - The action context (unused).
+     * @returns Resolves once the item update completes.
+     */
+    async setCarried(_context: SohlActionContext): Promise<void> {
+        const updateData: PlainObject = { "system.isCarried": true };
+        await this.data.update(updateData);
+    }
+
+    /**
+     * Marks this gear as not carried (stowed somewhere off-person).
+     *
+     * Intrinsic-action executor for the `setNotCarried` action.
+     *
+     * @param _context - The action context (unused).
+     * @returns Resolves once the item update completes.
+     */
+    async setNotCarried(_context: SohlActionContext): Promise<void> {
+        const updateData: PlainObject = { "system.isCarried": false };
+        await this.data.update(updateData);
+    }
+
+    /**
+     * Define and return all intrinsic actions for this logic type.
+     * @returns The base item actions plus the gear carried/not-carried actions.
+     */
+    static override defineIntrinsicActions(): Partial<SohlAction.Data>[] {
+        return [
+            ...SohlItemBaseLogic.defineIntrinsicActions(),
+            {
+                shortcode: "setCarried",
+                subType: ACTION_SUBTYPE.INTRINSIC,
+                title: "SOHL.Gear.Action.setCarried",
+                scope: SOHL_ACTION_SCOPE.SELF,
+                iconFAClass: "sohl-round-star-filled",
+                executor: "setCarried",
+                visible: "true",
+                group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
+            },
+            {
+                shortcode: "setNotCarried",
+                subType: ACTION_SUBTYPE.INTRINSIC,
+                title: "SOHL.Gear.Action.setNotCarried",
+                scope: SOHL_ACTION_SCOPE.SELF,
+                iconFAClass: "sohl-round-star-unfilled",
+                executor: "setNotCarried",
+                visible: "true",
+                group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
+            },
+        ];
     }
 
     /* --------------------------------------------- */

--- a/src/document/item/logic/MysteryLogic.ts
+++ b/src/document/item/logic/MysteryLogic.ts
@@ -82,6 +82,23 @@ export class MysteryLogic<
         max: ValueModifier;
     };
 
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
+    /**
+     * Invoke this mystery's power (spend a charge, request the boon, etc.).
+     *
+     * Intrinsic-action executor for the `useMystery` action.
+     *
+     * @param _context - The action context (speaker, scope) for the invocation.
+     * @remarks Not yet implemented; warns and returns.
+     */
+    async useMystery(_context: SohlActionContext): Promise<void> {
+        // TODO(#72) - Use Mystery
+        sohl.log.uiWarn(`Using "${this.name}" is not yet implemented.`);
+    }
+
     /**
      * Define and return all intrinsic actions for mystery logic.
      * @returns The intrinsic action definitions, including those inherited from the base logic.
@@ -100,19 +117,6 @@ export class MysteryLogic<
                 group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
             },
         ];
-    }
-
-    /**
-     * Invoke this mystery's power (spend a charge, request the boon, etc.).
-     *
-     * Intrinsic-action executor for the `useMystery` action.
-     *
-     * @param _context - The action context (speaker, scope) for the invocation.
-     * @remarks Not yet implemented; warns and returns.
-     */
-    async useMystery(_context: SohlActionContext): Promise<void> {
-        // TODO(#72) - Use Mystery
-        sohl.log.uiWarn(`Using "${this.name}" is not yet implemented.`);
     }
 
     /* --------------------------------------------- */

--- a/src/document/item/logic/MysticalAbilityLogic.ts
+++ b/src/document/item/logic/MysticalAbilityLogic.ts
@@ -104,26 +104,9 @@ export class MysticalAbilityLogic<
         max: ValueModifier;
     };
 
-    /**
-     * Define and return all intrinsic actions for mystical ability logic,
-     * adding the "perform" action to those inherited from the base logic.
-     * @returns The intrinsic action definitions.
-     */
-    static override defineIntrinsicActions(): Partial<SohlAction.Data>[] {
-        return [
-            ...SohlItemBaseLogic.defineIntrinsicActions(),
-            {
-                shortcode: "perform",
-                subType: ACTION_SUBTYPE.INTRINSIC,
-                title: "SOHL.MysticalAbility.Action.perform.title",
-                scope: SOHL_ACTION_SCOPE.SELF,
-                iconFAClass: "sohl-sparkles",
-                executor: "perform",
-                visible: "true",
-                group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
-            },
-        ];
-    }
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
 
     /**
      * Actively invoke this mystical ability (cast the spell, perform the rite,
@@ -143,6 +126,27 @@ export class MysticalAbilityLogic<
             `Performing "${this.name}" is not yet implemented.`,
         );
         return null;
+    }
+
+    /**
+     * Define and return all intrinsic actions for mystical ability logic,
+     * adding the "perform" action to those inherited from the base logic.
+     * @returns The intrinsic action definitions.
+     */
+    static override defineIntrinsicActions(): Partial<SohlAction.Data>[] {
+        return [
+            ...SohlItemBaseLogic.defineIntrinsicActions(),
+            {
+                shortcode: "perform",
+                subType: ACTION_SUBTYPE.INTRINSIC,
+                title: "SOHL.MysticalAbility.Action.perform.title",
+                scope: SOHL_ACTION_SCOPE.SELF,
+                iconFAClass: "sohl-sparkles",
+                executor: "perform",
+                visible: "true",
+                group: SOHL_CONTEXT_MENU_SORT_GROUP.ESSENTIAL,
+            },
+        ];
     }
 
     /* --------------------------------------------- */

--- a/src/document/item/logic/SkillLogic.ts
+++ b/src/document/item/logic/SkillLogic.ts
@@ -139,73 +139,6 @@ export class SkillLogic<
     fateMasteryLevel!: MasteryLevelModifier;
 
     /**
-     * Performs a success test against this skill's mastery level.
-     *
-     * Intrinsic-action executor for the `successTest` action; delegates to
-     * {@link MasteryLevelModifier.successTest}.
-     *
-     * @param context - The action context (speaker, scope) for the test.
-     * @returns The test result, `null` if cancelled, or `false` on error.
-     */
-    async successTest(
-        context: SohlActionContext,
-    ): Promise<SuccessTestResult | null | false> {
-        return this.masteryLevel.successTest(context);
-    }
-
-    /**
-     * Begins an opposed test backed by this skill's mastery level.
-     *
-     * Intrinsic-action executor for the `opposedTestStart` action. Opposed tests
-     * are token-based: this delegates into the actor's token logic
-     * {@link SohlTokenDocumentLogic.opposedTestStart}, passing this skill's
-     * `logicUuid` as the source — exactly as the weapon/technique combat actions
-     * delegate into the combatant.
-     *
-     * @param context - The action context (speaker, scope) for the test.
-     * @returns The opposed test result, or `null` if cancelled or unavailable.
-     */
-    async opposedTestStart(
-        context: SohlActionContext,
-    ): Promise<OpposedTestResult | null> {
-        const tokenLogic = fvttActiveTokenLogicForActor(this.actor);
-        if (!tokenLogic) {
-            sohl.log.uiWarn(
-                `${this.name} cannot start an opposed test: its actor has no token on the canvas.`,
-            );
-            return null;
-        }
-        (context.scope as PlainObject).logicUuid = this.uuid;
-        return tokenLogic.opposedTestStart(context);
-    }
-
-    /**
-     * Flags this skill for improvement via a Skill Development Roll.
-     *
-     * Intrinsic-action executor for the `setImproveFlag` action.
-     *
-     * @param _context - The action context (unused).
-     * @returns Resolves once the item update completes.
-     */
-    async setImproveFlag(_context: SohlActionContext): Promise<void> {
-        const updateData: PlainObject = { "system.improveFlag": true };
-        await this.data.update(updateData);
-    }
-
-    /**
-     * Clears this skill's improvement flag.
-     *
-     * Intrinsic-action executor for the `unsetImproveFlag` action.
-     *
-     * @param _context - The action context (unused).
-     * @returns Resolves once the item update completes.
-     */
-    async unsetImproveFlag(_context: SohlActionContext): Promise<void> {
-        const updateData: PlainObject = { "system.improveFlag": false };
-        await this.data.update(updateData);
-    }
-
-    /**
      * Performs a fate test for this skill, consuming a charge from an
      * applicable Fate mystery on success.
      *
@@ -247,82 +180,6 @@ export class SkillLogic<
             );
             fateItem.update(updateData);
         }
-    }
-
-    /**
-     * Attempts to improve the skill via a Skill Development Roll (SDR): rolls
-     * `1d100 + skillBase` against the current base mastery level, and on a
-     * success raises {@link SkillData.masteryLevelBase} by {@link sdrIncr}. The
-     * outcome is posted to chat regardless.
-     *
-     * @param context - The action context whose speaker receives the chat card.
-     * @returns Resolves once the roll is evaluated and the chat card is posted.
-     */
-    async improveWithSDR(context: SohlActionContext): Promise<void> {
-        const updateData: PlainObject = { "system.improveFlag": false };
-        const roll = SimpleRoll.fromFormula(`1d100+${this.skillBase.value}`);
-        roll.roll();
-        const isSuccess = roll.total > this.masteryLevel.base;
-
-        if (isSuccess) {
-            updateData["system.masteryLevelBase"] =
-                this.data.masteryLevelBase + this.sdrIncr;
-        }
-        const chatTemplate: FilePath = toFilePath(
-            "systems/sohl/templates/chat/standard-test-card.hbs",
-        );
-        const chatTemplateData = {
-            type: `${this.data.kind}-${this.name}-improve-sdr`,
-            title: sohl.i18n.format("SOHL.MasteryLevel.improveSDR.title", {
-                label: this.label,
-            }),
-            effTarget: this.masteryLevel.base,
-            isSuccess: isSuccess,
-            rollValue: roll.total,
-            rollResult: roll.result,
-            showResult: true,
-            resultText:
-                isSuccess ?
-                    sohl.i18n.format(
-                        "SOHL.MasteryLevel.improveSDR.increase.title",
-                        {
-                            label: this.label,
-                        },
-                    )
-                :   sohl.i18n.format(
-                        "SOHL.MasteryLevel.improveSDR.noIncrease.title",
-                        {
-                            label: this.label,
-                        },
-                    ),
-            resultDesc:
-                isSuccess ?
-                    //TODO(#70): "{label} increased by {incr} to {final}"
-                    sohl.i18n.format(
-                        "SOHL.MasteryLevel.improveSDR.increase.desc",
-                        {
-                            label: this.label,
-                            incr: this.sdrIncr,
-                            final: this.masteryLevel.base + this.sdrIncr,
-                        },
-                    )
-                :   sohl.i18n.format(
-                        "SOHL.MasteryLevel.improveSDR.noIncrease.desc",
-                        {
-                            label: this.label,
-                            incr: this.sdrIncr,
-                            final: this.masteryLevel.base + this.sdrIncr,
-                        },
-                    ),
-            description:
-                isSuccess ?
-                    sohl.i18n.format("SOHL.TestResult.SUCCESS")
-                :   sohl.i18n.format("SOHL.TestResult.FAILURE"),
-            notes: "",
-            sdrIncr: this.sdrIncr,
-        };
-
-        context.speaker.toChat(chatTemplate, chatTemplateData);
     }
 
     /**
@@ -409,6 +266,153 @@ export class SkillLogic<
     /** The amount by which {@link improveWithSDR} raises the base mastery level on success. */
     get sdrIncr() {
         return 1;
+    }
+
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
+    /**
+     * Performs a success test against this skill's mastery level.
+     *
+     * Intrinsic-action executor for the `successTest` action; delegates to
+     * {@link MasteryLevelModifier.successTest}.
+     *
+     * @param context - The action context (speaker, scope) for the test.
+     * @returns The test result, `null` if cancelled, or `false` on error.
+     */
+    async successTest(
+        context: SohlActionContext,
+    ): Promise<SuccessTestResult | null | false> {
+        return this.masteryLevel.successTest(context);
+    }
+
+    /**
+     * Begins an opposed test backed by this skill's mastery level.
+     *
+     * Intrinsic-action executor for the `opposedTestStart` action. Opposed tests
+     * are token-based: this delegates into the actor's token logic
+     * {@link SohlTokenDocumentLogic.opposedTestStart}, passing this skill's
+     * `logicUuid` as the source — exactly as the weapon/technique combat actions
+     * delegate into the combatant.
+     *
+     * @param context - The action context (speaker, scope) for the test.
+     * @returns The opposed test result, or `null` if cancelled or unavailable.
+     */
+    async opposedTestStart(
+        context: SohlActionContext,
+    ): Promise<OpposedTestResult | null> {
+        const tokenLogic = fvttActiveTokenLogicForActor(this.actor);
+        if (!tokenLogic) {
+            sohl.log.uiWarn(
+                `${this.name} cannot start an opposed test: its actor has no token on the canvas.`,
+            );
+            return null;
+        }
+        (context.scope as PlainObject).logicUuid = this.uuid;
+        return tokenLogic.opposedTestStart(context);
+    }
+
+    /**
+     * Flags this skill for improvement via a Skill Development Roll.
+     *
+     * Intrinsic-action executor for the `setImproveFlag` action.
+     *
+     * @param _context - The action context (unused).
+     * @returns Resolves once the item update completes.
+     */
+    async setImproveFlag(_context: SohlActionContext): Promise<void> {
+        const updateData: PlainObject = { "system.improveFlag": true };
+        await this.data.update(updateData);
+    }
+
+    /**
+     * Clears this skill's improvement flag.
+     *
+     * Intrinsic-action executor for the `unsetImproveFlag` action.
+     *
+     * @param _context - The action context (unused).
+     * @returns Resolves once the item update completes.
+     */
+    async unsetImproveFlag(_context: SohlActionContext): Promise<void> {
+        const updateData: PlainObject = { "system.improveFlag": false };
+        await this.data.update(updateData);
+    }
+
+    /**
+     * Attempts to improve the skill via a Skill Development Roll (SDR): rolls
+     * `1d100 + skillBase` against the current base mastery level, and on a
+     * success raises {@link SkillData.masteryLevelBase} by {@link sdrIncr}. The
+     * outcome is posted to chat regardless.
+     *
+     * @param context - The action context whose speaker receives the chat card.
+     * @returns Resolves once the roll is evaluated and the chat card is posted.
+     */
+    async improveWithSDR(context: SohlActionContext): Promise<void> {
+        const updateData: PlainObject = { "system.improveFlag": false };
+        const roll = SimpleRoll.fromFormula(`1d100+${this.skillBase.value}`);
+        roll.roll();
+        const isSuccess = roll.total > this.masteryLevel.base;
+
+        if (isSuccess) {
+            updateData["system.masteryLevelBase"] =
+                this.data.masteryLevelBase + this.sdrIncr;
+        }
+        const chatTemplate: FilePath = toFilePath(
+            "systems/sohl/templates/chat/standard-test-card.hbs",
+        );
+        const chatTemplateData = {
+            type: `${this.data.kind}-${this.name}-improve-sdr`,
+            title: sohl.i18n.format("SOHL.MasteryLevel.improveSDR.title", {
+                label: this.label,
+            }),
+            effTarget: this.masteryLevel.base,
+            isSuccess: isSuccess,
+            rollValue: roll.total,
+            rollResult: roll.result,
+            showResult: true,
+            resultText:
+                isSuccess ?
+                    sohl.i18n.format(
+                        "SOHL.MasteryLevel.improveSDR.increase.title",
+                        {
+                            label: this.label,
+                        },
+                    )
+                :   sohl.i18n.format(
+                        "SOHL.MasteryLevel.improveSDR.noIncrease.title",
+                        {
+                            label: this.label,
+                        },
+                    ),
+            resultDesc:
+                isSuccess ?
+                    //TODO(#70): "{label} increased by {incr} to {final}"
+                    sohl.i18n.format(
+                        "SOHL.MasteryLevel.improveSDR.increase.desc",
+                        {
+                            label: this.label,
+                            incr: this.sdrIncr,
+                            final: this.masteryLevel.base + this.sdrIncr,
+                        },
+                    )
+                :   sohl.i18n.format(
+                        "SOHL.MasteryLevel.improveSDR.noIncrease.desc",
+                        {
+                            label: this.label,
+                            incr: this.sdrIncr,
+                            final: this.masteryLevel.base + this.sdrIncr,
+                        },
+                    ),
+            description:
+                isSuccess ?
+                    sohl.i18n.format("SOHL.TestResult.SUCCESS")
+                :   sohl.i18n.format("SOHL.TestResult.FAILURE"),
+            notes: "",
+            sdrIncr: this.sdrIncr,
+        };
+
+        context.speaker.toChat(chatTemplate, chatTemplateData);
     }
 
     /**

--- a/src/document/item/logic/SohlItemBaseLogic.ts
+++ b/src/document/item/logic/SohlItemBaseLogic.ts
@@ -68,6 +68,10 @@ export interface SohlItemData<
 export class SohlItemBaseLogic<
     TData extends SohlItemData = SohlItemData,
 > extends SohlLogic<TData> {
+    /* --------------------------------------------- */
+    /* Common Lifecycle Actions                      */
+    /* --------------------------------------------- */
+
     /** @inheritDoc */
     override initialize(): void {}
     /** @inheritDoc */

--- a/src/document/item/logic/TraumaLogic.ts
+++ b/src/document/item/logic/TraumaLogic.ts
@@ -84,6 +84,10 @@ export class TraumaLogic<
      */
     bodyLocation: BodyLocation | undefined;
 
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
+
     /**
      * Roll the treatment test, applying medical care to this trauma.
      *

--- a/src/document/item/logic/WeaponGearLogic.ts
+++ b/src/document/item/logic/WeaponGearLogic.ts
@@ -110,7 +110,7 @@ export class WeaponGearLogic<
     }
 
     /* --------------------------------------------- */
-    /* Combat Intrinsic Actions                            */
+    /* Intrinsic Actions                             */
     /* --------------------------------------------- */
 
     /**

--- a/src/document/token/logic/SohlTokenDocumentLogic.ts
+++ b/src/document/token/logic/SohlTokenDocumentLogic.ts
@@ -70,15 +70,6 @@ interface OpposedItemLogic {
 export class SohlTokenDocumentLogic<
     TData extends TokenData = TokenData,
 > extends SohlLogic<TData> {
-    /** @inheritdoc */
-    override initialize(): void {}
-
-    /** @inheritdoc */
-    override evaluate(): void {}
-
-    /** @inheritdoc */
-    override finalize(): void {}
-
     /** This token's actor name, for dialog/warning text. */
     private get actorName(): string {
         return this.actorLogic?.name ?? this.name;
@@ -101,6 +92,10 @@ export class SohlTokenDocumentLogic<
                 !il.masteryLevel.disabled,
         ) as OpposedItemLogic[];
     }
+
+    /* --------------------------------------------- */
+    /* Intrinsic Actions                             */
+    /* --------------------------------------------- */
 
     /**
      * Begin an opposed test from this (the **source**) token — the canonical
@@ -241,4 +236,17 @@ export class SohlTokenDocumentLogic<
             },
         ];
     }
+
+    /* --------------------------------------------- */
+    /* Common Lifecycle Actions                      */
+    /* --------------------------------------------- */
+
+    /** @inheritdoc */
+    override initialize(): void {}
+
+    /** @inheritdoc */
+    override evaluate(): void {}
+
+    /** @inheritdoc */
+    override finalize(): void {}
 }


### PR DESCRIPTION
## Context

Logic classes had inconsistent internal organization: intrinsic-action executors, helper methods, `defineIntrinsicActions()`, and lifecycle methods appeared in varying orders, and only a few files carried section-divider comments. This applies the existing `AttributeLogic` convention uniformly so every Logic class groups its intrinsic actions and its phase-batched lifecycle methods under consistent headers.

## What changed

Two canonical dividers applied across **14 Logic files**:

```
/* --------------------------------------------- */
/* Intrinsic Actions                             */
/* --------------------------------------------- */

/* --------------------------------------------- */
/* Common Lifecycle Actions                      */
/* --------------------------------------------- */
```

- **Header insert only** (already ordered): `AfflictionLogic`, `TraumaLogic`, `BeingLogic`
- **Normalize** `Combat Intrinsic Actions` → `Intrinsic Actions`: `WeaponGearLogic`, `CombatTechniqueLogic`
- **Reorder executors before `defineIntrinsicActions`**: `GearLogic`, `MysteryLogic`, `MysticalAbilityLogic`
- **Full regroup**: `SkillLogic` — pulled `fateTest`/`recalculate` (not intrinsic actions) out from among the executors; grouped the five real executors + `defineIntrinsicActions` under the header
- **Lifecycle stubs moved top → bottom**: `CombatantLogic`, `SohlTokenDocumentLogic`, `SohlActorBaseLogic`, `SohlItemBaseLogic`

### Judgment calls

- **`SohlLogic.ts`** is on the "do not touch without explicit instruction" list — changes here are **comment-only** (no method reordering); the existing phase-batched-lifecycle doc was preserved.
- Private support helpers (`CombatantLogic` combat-result builders, `BeingLogic.aggregateArmorProtection`) left adjacent to the code they support rather than hoisted.
- `SohlSceneLogic` skipped — plain class, no lifecycle/intrinsic actions.

Pure reorganization and comments — **no behavior change**.

## Verification

- `npm run build:types` — clean
- `npm run test` — 1237 passed, 0 failed
- `npx eslint` on changed files — clean
- `npm run lint:todos` — clean