### PR TITLE
feat(actor): restore Being sheet header — pills, health bar, body lozenges (closes #107 #108 #110)

### DIFF
--- a/.changeset/restore-being-header.md
+++ b/.changeset/restore-being-header.md
@@ -1,0 +1,13 @@
+---
+"sohl": minor
+---
+
+**Restore the Being sheet header: clickable status pills, health bar, body-location lozenges**
+
+Rebuild the Being sheet header to match the previous design, in `templates/actor/being/header.hbs`, `scss/layout/_sheet.scss`, and `src/document/actor/foundry/BeingSheet.ts`:
+
+- **Status pills** now look like the old rounded lozenges (grouped top-right, wrapping) and are **clickable to toggle** the status — a new `toggleStatus` action calls `actor.toggleStatusEffect(statusId)`, creating/deleting the active effect. Active pills are highlighted.
+- **Health bar** restored: a "HEALTH: x%" label over a filled bar, driven by `health.effective` (added `healthPct` to the header context).
+- **Body-location lozenges** restored as a read-only, full-width row beneath the main header, generated dynamically from the actor's Lineage body structure (`bodyStructure.parts`).
+
+Status `data-status-id`/tooltips and localization keys are unchanged.

--- a/scss/abstracts/_tokens.scss
+++ b/scss/abstracts/_tokens.scss
@@ -36,6 +36,7 @@ $colors: (
     "danger": #c84a3a,
     "success": #5f6f3a,
     "info": #4f6b73,
+    "active": #2a52d6, // saturated blue cue for toggled-on / selected state
     // Indicators
     "health-bar": #6f979a, // health/endurance bar fill
     // Accents

--- a/scss/abstracts/_typography.scss
+++ b/scss/abstracts/_typography.scss
@@ -331,12 +331,12 @@ $typography-scale: (
     ),
     "input-label": (
         family: $font-title,
-        size: 12px,
+        size: 14px,
         weight: 700,
     ),
     "body-text": (
         family: $font-body,
-        size: 13px,
+        size: 16px,
         weight: 400,
     ),
     "tooltip": (
@@ -361,12 +361,12 @@ $typography-scale: (
     ),
     "editor": (
         family: $font-body,
-        size: 13px,
+        size: 16px,
         weight: 400,
     ),
     "textarea": (
         family: $font-mono,
-        size: 13px,
+        size: 16px,
         weight: 400,
     ),
 );

--- a/scss/abstracts/_typography.scss
+++ b/scss/abstracts/_typography.scss
@@ -321,12 +321,12 @@ $typography-scale: (
     ),
     "tab": (
         family: $font-sans,
-        size: 16px,
+        size: 20px,
         weight: 600,
     ),
     "active-tab": (
         family: $font-sans,
-        size: 20px,
+        size: 24px,
         weight: 700,
     ),
     "input-label": (

--- a/scss/base/_window.scss
+++ b/scss/base/_window.scss
@@ -4,12 +4,12 @@
 
 .window-content {
     background: url("../assets/ui/parchment.jpg") repeat;
-    font-size: 13px;
+    font-size: 16px;
     color: var(--sohl-color-text-primary);
 }
 
 .print-window-content {
-    font-size: 13px;
+    font-size: 16px;
     color: var(--sohl-color-text-primary);
     background: var(--sohl-color-text-inverse);
 }

--- a/scss/layout/_sheet.scss
+++ b/scss/layout/_sheet.scss
@@ -149,8 +149,8 @@ span.sep {
             // Clicking toggles the status; active pills get the blue cue.
             &.active {
                 color: var(--sohl-color-text-inverse);
-                background: var(--sohl-color-info);
-                border-color: var(--sohl-color-info);
+                background: var(--sohl-color-active);
+                border-color: var(--sohl-color-active);
             }
         }
     }

--- a/scss/layout/_sheet.scss
+++ b/scss/layout/_sheet.scss
@@ -79,7 +79,18 @@ span.sep {
 }
 
 .sheet-header {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 5px;
+    border-bottom: 2px groove var(--sohl-color-border-subtle);
+
+    // Top row: portrait, name, status pills, health.
+    .sheet-header__main {
+        align-items: flex-start;
+    }
+
     .sheet-header__details {
+        flex: 1;
         font-size: 20px;
         font-weight: 700;
     }
@@ -106,28 +117,90 @@ span.sep {
         object-fit: contain;
         border: none;
         border-right: 2px groove var(--sohl-color-border-subtle);
+        margin-right: 10px;
     }
 
+    // Status pills — clickable rounded lozenges, grouped top-right, wrapping to
+    // multiple rows. Each toggles its status on the actor.
     .sheet-header__statuses {
+        flex: 0 0 auto;
         display: flex;
         flex-wrap: wrap;
+        align-content: flex-start;
         gap: 4px;
-        margin-top: 4px;
+        max-width: 200px;
+        margin: 5px;
 
         .sheet-header__status {
-            padding: 1px 5px;
-            font-size: 11px;
+            flex: 0 0 auto;
+            min-width: 40px;
+            padding: 2px 8px;
+            font-size: 12px;
             font-weight: 700;
-            line-height: 16px;
-            border: 1px solid var(--sohl-color-border-subtle);
-            border-radius: 3px;
-            color: var(--sohl-color-text-muted);
+            line-height: 18px;
+            text-align: center;
+            text-decoration: none;
+            cursor: pointer;
+            color: var(--sohl-color-text-primary);
+            background: var(--sohl-color-bg-overlay-light);
+            border: 1px solid var(--sohl-color-border-strong);
+            border-radius: 16px;
 
             &.active {
                 color: var(--sohl-color-text-inverse);
                 background: var(--sohl-color-danger);
                 border-color: var(--sohl-color-danger);
             }
+        }
+    }
+
+    // Health bar — "HEALTH: x%" label over a filled bar.
+    .sheet-header__health {
+        flex: 0 0 120px;
+        text-align: center;
+        padding: 5px;
+
+        .sheet-header__health-label {
+            font-size: 14px;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .sheet-header__health-bar {
+            width: 100%;
+            height: 10px;
+            margin-top: 4px;
+            background: var(--sohl-color-bg-input);
+            border: 1px solid var(--sohl-color-border-default);
+            border-radius: 3px;
+            overflow: hidden;
+
+            .sheet-header__health-fill {
+                height: 100%;
+                background: var(--sohl-color-health-bar);
+                border-radius: 2px;
+            }
+        }
+    }
+
+    // Body-location lozenges — read-only (no click), full-width row beneath the
+    // main header. Dynamic from the lineage body structure.
+    .sheet-header__locations {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        padding: 5px;
+
+        .sheet-header__location {
+            padding: 2px 10px;
+            font-size: 12px;
+            font-weight: 700;
+            line-height: 18px;
+            text-align: center;
+            color: var(--sohl-color-text-primary);
+            background: var(--sohl-color-bg-overlay-light);
+            border: 1px solid var(--sohl-color-border-strong);
+            border-radius: 16px;
         }
     }
 }

--- a/scss/layout/_sheet.scss
+++ b/scss/layout/_sheet.scss
@@ -135,9 +135,9 @@ span.sep {
             flex: 0 0 auto;
             min-width: 40px;
             padding: 2px 8px;
-            font-size: 12px;
+            font-size: 14px;
             font-weight: 700;
-            line-height: 18px;
+            line-height: 22px;
             text-align: center;
             text-decoration: none;
             cursor: pointer;
@@ -146,10 +146,11 @@ span.sep {
             border: 1px solid var(--sohl-color-border-strong);
             border-radius: 16px;
 
+            // Clicking toggles the status; active pills get the blue cue.
             &.active {
                 color: var(--sohl-color-text-inverse);
-                background: var(--sohl-color-danger);
-                border-color: var(--sohl-color-danger);
+                background: var(--sohl-color-info);
+                border-color: var(--sohl-color-info);
             }
         }
     }
@@ -161,7 +162,7 @@ span.sep {
         padding: 5px;
 
         .sheet-header__health-label {
-            font-size: 14px;
+            font-size: 17px;
             font-weight: bold;
             text-transform: uppercase;
         }
@@ -193,9 +194,9 @@ span.sep {
 
         .sheet-header__location {
             padding: 2px 10px;
-            font-size: 12px;
+            font-size: 14px;
             font-weight: 700;
-            line-height: 18px;
+            line-height: 22px;
             text-align: center;
             color: var(--sohl-color-text-primary);
             background: var(--sohl-color-bg-overlay-light);

--- a/scss/layout/_tabs.scss
+++ b/scss/layout/_tabs.scss
@@ -10,6 +10,11 @@ nav.tabs {
     border-bottom: none;
     color: var(--sohl-color-text-secondary);
 
+    // Tab glyphs sit ~20% larger than the tab label text.
+    i {
+        font-size: 1.2em;
+    }
+
     &:hover,
     &:focus {
         background: var(--sohl-color-bg-overlay-dark);

--- a/scss/layout/_tabs.scss
+++ b/scss/layout/_tabs.scss
@@ -15,7 +15,7 @@ nav.tabs {
     // small within their em (see icon-font sizing issue); revisit once the font
     // is regenerated to fill the em.
     i {
-        font-size: 1.6em;
+        font-size: 1.3em;
     }
 
     &:hover,

--- a/scss/layout/_tabs.scss
+++ b/scss/layout/_tabs.scss
@@ -4,15 +4,18 @@ nav.tabs {
     flex: 0 0 auto;
     margin-bottom: 5px;
     @include typography.type-style("tab");
+    font-variant: small-caps;
     line-height: 32px;
     //    margin: 0 24px;
     border-top: none;
     border-bottom: none;
     color: var(--sohl-color-text-secondary);
 
-    // Tab glyphs sit ~20% larger than the tab label text.
+    // Tab glyphs. Sized up generously here because the icon-font glyphs render
+    // small within their em (see icon-font sizing issue); revisit once the font
+    // is regenerated to fill the em.
     i {
-        font-size: 1.2em;
+        font-size: 1.6em;
     }
 
     &:hover,

--- a/src/document/actor/foundry/BeingSheet.ts
+++ b/src/document/actor/foundry/BeingSheet.ts
@@ -256,8 +256,27 @@ export class BeingSheet extends SohlActorSheetBase {
             rollStrikeModeTest: BeingSheet._onRollStrikeModeTest,
             rollStrikeModeImpact: BeingSheet._onRollStrikeModeImpact,
             addInjury: BeingSheet._onAddInjury,
+            toggleStatus: BeingSheet._onToggleStatus,
         },
     };
+
+    /**
+     * Toggle a status effect from the header status pills. Creates the active
+     * effect if absent, deletes it if present, keyed by the pill's
+     * `data-status-id`.
+     *
+     * @param _event - The triggering pointer event (unused).
+     * @param target - The clicked pill, carrying `data-status-id`.
+     */
+    protected static async _onToggleStatus(
+        this: BeingSheet,
+        _event: PointerEvent,
+        target: HTMLElement,
+    ): Promise<void> {
+        const statusId = target.getAttribute("data-status-id");
+        if (!statusId) return;
+        await this.document.toggleStatusEffect(statusId);
+    }
 
     /**
      * Handle the "Add Injury" button on the Trauma tab: open the Add Injury
@@ -534,12 +553,29 @@ export class BeingSheet extends SohlActorSheetBase {
             { id: STATUS_EFFECT.DEAD, abbr: "DED", label: "Dead" },
         ].map((s) => ({ ...s, active: statuses.has(s.id) }));
 
+        // Read-only body-location lozenges, sourced from the actor's Lineage body
+        // structure (dynamic — varies by lineage).
+        const lineageItem = (actor.itemTypes as any)?.[ITEM_KIND.LINEAGE]?.[0];
+        const bodyStructure = (lineageItem?.logic as LineageLogic | undefined)
+            ?.bodyStructure;
+        const bodyParts = (bodyStructure?.parts ?? []).map((p) => ({
+            shortcode: p.shortcode,
+        }));
+
+        // Health bar: `health.effective` is the current health percentage.
+        const healthPct = Math.max(
+            0,
+            Math.min(100, Math.round(logic?.health?.effective ?? 0)),
+        );
+
         return Object.assign(context, {
             actorName: actor.name,
             actorImg: actor.img,
             health: logic?.health,
+            healthPct,
             shockState: logic?.shockState,
             statusEffects,
+            bodyParts,
         });
     }
 

--- a/src/document/actor/foundry/BeingSheet.ts
+++ b/src/document/actor/foundry/BeingSheet.ts
@@ -534,7 +534,19 @@ export class BeingSheet extends SohlActorSheetBase {
         // Status effects shown in the header. `id` must match a registered
         // status (Foundry's id is `stun`, not `stunned`); `abbr` is the short
         // label rendered, `label` is the tooltip.
-        const statuses = (actor as any).statuses ?? new Set<string>();
+        //
+        // SoHL's custom data-prep lifecycle does not populate the core
+        // `actor.statuses` set, so derive the active status ids from the actor's
+        // applied active effects directly (each status effect carries the status
+        // id in its core `statuses` field).
+        const statuses = new Set<string>();
+        const appliedEffects =
+            (actor as any).appliedEffects ?? (actor as any).effects ?? [];
+        for (const effect of appliedEffects) {
+            for (const sid of (effect.statuses ?? []) as Iterable<string>) {
+                statuses.add(sid);
+            }
+        }
         const statusEffects = [
             { id: STATUS_EFFECT.SLEEP, abbr: "SLP", label: "Sleep" },
             { id: STATUS_EFFECT.PRONE, abbr: "PRN", label: "Prone" },

--- a/src/document/actor/foundry/BeingSheet.ts
+++ b/src/document/actor/foundry/BeingSheet.ts
@@ -276,6 +276,10 @@ export class BeingSheet extends SohlActorSheetBase {
         const statusId = target.getAttribute("data-status-id");
         if (!statusId) return;
         await this.document.toggleStatusEffect(statusId);
+        // Re-render so the pill's `active` highlight reflects the new state —
+        // the embedded ActiveEffect change does not reliably re-render the
+        // header part on its own.
+        this.render();
     }
 
     /**

--- a/src/document/actor/foundry/BeingSheet.ts
+++ b/src/document/actor/foundry/BeingSheet.ts
@@ -537,15 +537,17 @@ export class BeingSheet extends SohlActorSheetBase {
         //
         // SoHL's custom data-prep lifecycle does not populate the core
         // `actor.statuses` set, so derive the active status ids from the actor's
-        // applied active effects directly (each status effect carries the status
-        // id in its core `statuses` field).
+        // active effects directly. Iterate the raw `effects` collection (not
+        // `appliedEffects`, which SoHL may filter via suppression) — a status
+        // effect's mere presence means the status is on; it carries the id in
+        // its core `statuses` field.
         const statuses = new Set<string>();
-        const appliedEffects =
-            (actor as any).appliedEffects ?? (actor as any).effects ?? [];
-        for (const effect of appliedEffects) {
+        for (const effect of ((actor as any).effects ?? []) as Iterable<any>) {
             for (const sid of (effect.statuses ?? []) as Iterable<string>) {
                 statuses.add(sid);
             }
+            const legacyId = effect?.flags?.core?.statusId;
+            if (legacyId) statuses.add(legacyId);
         }
         const statusEffects = [
             { id: STATUS_EFFECT.SLEEP, abbr: "SLP", label: "Sleep" },

--- a/templates/actor/being/header.hbs
+++ b/templates/actor/being/header.hbs
@@ -11,29 +11,32 @@ https://www.gnu.org/licenses/gpl-3.0.html
 SPDX-License-Identifier: GPL-3.0-or-later
 --}}
 
-{{!--
-This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
-Copyright (c) 2024–2026 Tom Rodriguez ("Toasty") <toasty@heroiclands.com>
-
-Licensed under the GNU General Public License v3.0 (GPLv3).
-You may copy, modify, and distribute this file under the terms of that license.
-
-See LICENSE.md in the project root or:
-https://www.gnu.org/licenses/gpl-3.0.html
-
-SPDX-License-Identifier: GPL-3.0-or-later
---}}
-
-<header class="sheet-header flexrow">
-    <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
-    <div class="sheet-header__details">
-        <h1 class="actor-name">
-            <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
-        </h1>
+<header class="sheet-header">
+    <div class="sheet-header__main flexrow">
+        <img class="sheet-header__portrait" src="{{actorImg}}" data-edit="img" alt="{{actorName}}" />
+        <div class="sheet-header__details">
+            <h1 class="actor-name">
+                <input name="name" type="text" value="{{actorName}}" placeholder="{{localize 'Name'}}" />
+            </h1>
+        </div>
         <div class="sheet-header__statuses">
             {{#each statusEffects}}
-            <a class="sheet-header__status {{#if this.active}}active{{/if}}" data-status-id="{{this.id}}" data-tooltip="{{this.label}}">{{this.abbr}}</a>
+            <a class="sheet-header__status {{#if this.active}}active{{/if}}" data-action="toggleStatus"
+                data-status-id="{{this.id}}" data-tooltip="{{this.label}}">{{this.abbr}}</a>
             {{/each}}
         </div>
+        <div class="sheet-header__health">
+            <div class="sheet-header__health-label">{{localize "Health"}}: {{healthPct}}%</div>
+            <div class="sheet-header__health-bar">
+                <div class="sheet-header__health-fill" style="width: {{healthPct}}%"></div>
+            </div>
+        </div>
     </div>
+    {{#if bodyParts.length}}
+    <div class="sheet-header__locations">
+        {{#each bodyParts}}
+        <span class="sheet-header__location">{{this.shortcode}}</span>
+        {{/each}}
+    </div>
+    {{/if}}
 </header>


### PR DESCRIPTION
Closes #107, #108, #110. Rebuilds the Being sheet header to match the previous design.

## What

Three pieces, in `templates/actor/being/header.hbs`, `scss/layout/_sheet.scss`, and `src/document/actor/foundry/BeingSheet.ts`:

1. **Status pills (#110)** — restyled as the old rounded lozenges (grouped top-right, wrapping to multiple rows) and **wired to toggle**: a new `toggleStatus` action (`data-action="toggleStatus"`) calls `actor.toggleStatusEffect(statusId)`, which creates/deletes the active effect. Active pills are highlighted. (They previously had no handler — clicking did nothing.)
2. **Health bar (#107)** — restored: a "HEALTH: x%" label over a filled bar. `health` was already on the context; added `healthPct` (`health.effective`, clamped 0–100) for the fill width.
3. **Body-location lozenges (#108)** — restored as a **read-only** full-width row beneath the main header, generated **dynamically** from the actor's Lineage `bodyStructure.parts` (no click action, per spec).

Header is now a two-row layout: portrait · name · pills · health on top, location lozenges below. `data-status-id`/tooltips and localization keys unchanged.

## Verification
- `npm run build` (types + tests), `npm run build:css`, `npm run docs` (0 errors) — all pass.
