### PR TITLE
refactor: move pure view-model logic out of sheets into Foundry-free modules (#117)

### DIFF
--- a/.changeset/sheet-logic-extraction.md
+++ b/.changeset/sheet-logic-extraction.md
@@ -27,3 +27,10 @@ overwrite-on-drop). The sheet keeps the Foundry-facing drop dialog and mutation.
 _SohlActiveEffectSheet_ → new `effect-sheet-view.ts`: `buildChangeTypesMap` (the
 localized change-`mode` label map), `resolveEffectMetadataType` (scope → effect-key
 namespace), and `resolveEffectKeyChoices` (its `ITEM_METADATA` key-choices lookup).
+
+_Settings apps_ → new `src/apps/logic/domain-manager-view.ts` (`buildDomainGroups` —
+group by family, sort, and compute delete/override flags) and
+`src/apps/logic/calendar-settings-view.ts` (`buildCalendarViewModel` — the calendar
+dropdown rows and imported-calendar list, taking a `localize` callback). The new
+`src/apps/logic/**` directory is added to the Foundry-free zones (the ESLint
+boundary rule and the purity smoke test).

--- a/.changeset/sheet-logic-extraction.md
+++ b/.changeset/sheet-logic-extraction.md
@@ -1,0 +1,20 @@
+---
+"sohl": patch
+---
+
+**Move pure view-model logic out of sheet classes into Foundry-free modules**
+
+Fixes [#117](https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/issues/117).
+
+Pure data-shaping that had been written inline inside Foundry sheet classes — where
+it was excluded from test coverage and sat outside the Foundry-free boundary guards
+(the ESLint logic-zone rule and the purity test) — moves into co-located `*-view`
+helper modules under each document's `logic/` directory, each with unit tests. The
+sheets keep only their Foundry-facing orchestration. No user-facing behavior change.
+
+_BeingSheet_ → new `being-sheet-view.ts`: `groupBySubType` (replacing five inline
+copies across skills, traits, afflictions, mysteries, and abilities),
+`buildContainerTree` (the gear hierarchy and virtual "On Body" list),
+`buildStatusPills`, `buildBodyPartLozenges`, `clampHealthPct`, and
+`splitWeaponsByRange`. The in-sheet `fvttEnrichHTML` proxy is replaced with a direct
+`TextEditor` call (the proxy exists for the logic layer, not for sheets).

--- a/.changeset/sheet-logic-extraction.md
+++ b/.changeset/sheet-logic-extraction.md
@@ -23,3 +23,7 @@ _SohlItemSheetBase_ → new `item-sheet-view.ts`: `localizeSubType` (subtype-lab
 localization with raw fallback), `keyTransferredEffects` (enabled transferred
 effects keyed by id), and `findSimilarItem` (the name/type/subtype match behind
 overwrite-on-drop). The sheet keeps the Foundry-facing drop dialog and mutation.
+
+_SohlActiveEffectSheet_ → new `effect-sheet-view.ts`: `buildChangeTypesMap` (the
+localized change-`mode` label map), `resolveEffectMetadataType` (scope → effect-key
+namespace), and `resolveEffectKeyChoices` (its `ITEM_METADATA` key-choices lookup).

--- a/.changeset/sheet-logic-extraction.md
+++ b/.changeset/sheet-logic-extraction.md
@@ -18,3 +18,8 @@ copies across skills, traits, afflictions, mysteries, and abilities),
 `buildStatusPills`, `buildBodyPartLozenges`, `clampHealthPct`, and
 `splitWeaponsByRange`. The in-sheet `fvttEnrichHTML` proxy is replaced with a direct
 `TextEditor` call (the proxy exists for the logic layer, not for sheets).
+
+_SohlItemSheetBase_ → new `item-sheet-view.ts`: `localizeSubType` (subtype-label
+localization with raw fallback), `keyTransferredEffects` (enabled transferred
+effects keyed by id), and `findSimilarItem` (the name/type/subtype match behind
+overwrite-on-drop). The sheet keeps the Foundry-facing drop dialog and mutation.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -62,6 +62,14 @@ Pure game-mechanics objects in `src/domain/` — modifiers, test results, body s
 
 Sheet classes and Handlebars templates (`.hbs`) handle UI. Sheets extend `SohlActorSheetBase` or `SohlItemSheetBase`. Chat cards use templates in `templates/chat/`.
 
+#### Sheet view-model modules
+
+A sheet (or settings app) is Foundry code: it owns the DOM, fires hooks, mutates documents, and enriches HTML. But its `_prepare*Context` methods often also contain **pure data-shaping** — grouping, sorting, hierarchy building, label/scope resolution. That logic belongs in the Foundry-free layer, not inline in the sheet, so it can be unit-tested and is covered by the boundary guards.
+
+The convention: a sheet/app class `FooSheet`/`FooApp` with pure view-model logic gets a `foo-sheet-view.ts` (apps: `foo-view.ts`) module of free functions in the **sibling `logic/` directory** (e.g. `actor/logic/being-sheet-view.ts`, `apps/logic/domain-manager-view.ts`). These take accessor callbacks or minimal structural inputs — never Foundry document types — so they stay value-Foundry-free; the sheet keeps only orchestration and delegates the shaping. The canonical example is `being-sheet-view.ts`.
+
+Create such a module **only when there is real logic to hold** — trivial field-injection (`system.foo → context.foo`) stays inline. Don't add empty placeholder modules.
+
 ## Three-class pattern
 
 Every actor and item type is split into three classes across two directories:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,7 @@ const FOUNDRY_FREE_ZONES = [
     "src/document/token/logic/**/*.ts",
     "src/document/scene/logic/**/*.ts",
     "src/document/effect/logic/**/*.ts",
+    "src/apps/logic/**/*.ts",
     "src/domain/**/*.ts",
     "src/core/SohlLogic.ts",
     "src/core/SohlActionContext.ts",

--- a/src/apps/CalendarSettingsMenu.ts
+++ b/src/apps/CalendarSettingsMenu.ts
@@ -13,7 +13,6 @@
 
 import { SohlSystem } from "@src/core/SohlSystem";
 
- 
 const CalendarSettingsMenu_Base: any =
     foundry.applications.api.HandlebarsApplicationMixin(
         foundry.applications.api.ApplicationV2,

--- a/src/apps/CalendarSettingsMenu.ts
+++ b/src/apps/CalendarSettingsMenu.ts
@@ -12,6 +12,7 @@
  */
 
 import { SohlSystem } from "@src/core/SohlSystem";
+import { buildCalendarViewModel } from "@src/apps/logic/calendar-settings-view";
 
 const CalendarSettingsMenu_Base: any =
     foundry.applications.api.HandlebarsApplicationMixin(
@@ -68,24 +69,11 @@ export class CalendarSettingsMenu extends (CalendarSettingsMenu_Base as typeof f
      */
     protected override async _prepareContext(options: any): Promise<any> {
         const activeId = game.settings.get("sohl", "activeCalendar") as string;
-        const calendars: { id: string; label: string; active: boolean }[] = [];
-        for (const [id, reg] of SohlSystem.calendars.entries()) {
-            calendars.push({
-                id,
-                label: game.i18n.localize(reg.label),
-                active: id === activeId,
-            });
-        }
-
-        const imported: { id: string; label: string }[] = [];
-        for (const [id, reg] of SohlSystem.calendars.entries()) {
-            if (!reg.builtin) {
-                imported.push({
-                    id,
-                    label: game.i18n.localize(reg.label),
-                });
-            }
-        }
+        const { calendars, imported } = buildCalendarViewModel(
+            SohlSystem.calendars.entries(),
+            activeId,
+            (key) => game.i18n.localize(key),
+        );
 
         return {
             calendars,

--- a/src/apps/DomainManagerApp.ts
+++ b/src/apps/DomainManagerApp.ts
@@ -18,22 +18,12 @@ import {
     domainFamilyLabels,
     type DomainFamily,
 } from "@src/utils/constants";
+import { buildDomainGroups } from "@src/apps/logic/domain-manager-view";
 
 const DomainManagerApp_Base: any =
     foundry.applications.api.HandlebarsApplicationMixin(
         foundry.applications.api.ApplicationV2,
     );
-
-interface RenderRow extends DomainEntry {
-    canDelete: boolean;
-    isOverride: boolean;
-}
-
-interface RenderGroup {
-    family: DomainFamily;
-    familyLabel: string;
-    entries: RenderRow[];
-}
 
 /**
  * GM-facing manager for the world-scoped Domain registry. Lists all
@@ -82,52 +72,7 @@ export class DomainManagerApp extends (DomainManagerApp_Base as typeof foundry.a
      * @returns The template context of domain groups and an emptiness flag.
      */
     protected override async _prepareContext(_options: any): Promise<any> {
-        const all = SohlDomains.getAll();
-        const grouped = new Map<DomainFamily, RenderRow[]>();
-        for (const family of DomainFamilies) {
-            grouped.set(family as DomainFamily, []);
-        }
-        for (const entry of Object.values(all)) {
-            const family = entry.family;
-            const list = grouped.get(family);
-            if (!list) continue;
-            list.push({
-                ...entry,
-                canDelete: entry.source === "world",
-                // The current registry stores only the active entry per
-                // shortcode, so we cannot detect "overridden a default" by
-                // looking at the live registry alone. We mark world
-                // entries whose shortcode begins with `sohl.` as overrides
-                // — that is the only way a GM can shadow a system default
-                // through the UI.
-                isOverride:
-                    entry.source === "world" &&
-                    entry.shortcode.startsWith("sohl."),
-            });
-        }
-        // Sort within each family by sort then label.
-        for (const [, list] of grouped) {
-            list.sort((a, b) => {
-                if (a.sort !== b.sort) return a.sort - b.sort;
-                return a.label.localeCompare(b.label);
-            });
-        }
-
-        const groups: RenderGroup[] = [];
-        for (const [family, entries] of grouped) {
-            if (entries.length === 0) continue;
-            const familyKey = Object.entries(DOMAIN_FAMILY).find(
-                ([, v]) => v === family,
-            )?.[0];
-            const familyLabel =
-                familyKey ?
-                    domainFamilyLabels[
-                        familyKey as keyof typeof domainFamilyLabels
-                    ]
-                :   family;
-            groups.push({ family, familyLabel, entries });
-        }
-
+        const groups = buildDomainGroups(Object.values(SohlDomains.getAll()));
         return {
             groups,
             isEmpty: groups.length === 0,

--- a/src/apps/DomainManagerApp.ts
+++ b/src/apps/DomainManagerApp.ts
@@ -19,7 +19,6 @@ import {
     type DomainFamily,
 } from "@src/utils/constants";
 
- 
 const DomainManagerApp_Base: any =
     foundry.applications.api.HandlebarsApplicationMixin(
         foundry.applications.api.ApplicationV2,

--- a/src/apps/logic/calendar-settings-view.ts
+++ b/src/apps/logic/calendar-settings-view.ts
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Foundry-free view-model builder for the Calendar settings menu
+ * ({@link CalendarSettingsMenu}): turn the calendar registry into the dropdown
+ * rows and the imported-calendar list. Pure — the app supplies the registry
+ * entries, the active id, and a `localize` callback (so no `game.i18n` here).
+ */
+
+/** The registry fields the calendar view needs from each calendar. */
+export interface CalendarRegEntry {
+    /** The calendar's display-label localization key. */
+    label: string;
+    /** Whether the calendar ships with the system (vs. user-imported). */
+    builtin?: boolean;
+}
+
+/** A calendar row for the active-calendar dropdown. */
+export interface CalendarRow {
+    /** The calendar id. */
+    id: string;
+    /** The localized calendar label. */
+    label: string;
+    /** Whether this is the active calendar. */
+    active: boolean;
+}
+
+/** A row in the imported-calendars list. */
+export interface ImportedCalendarRow {
+    /** The calendar id. */
+    id: string;
+    /** The localized calendar label. */
+    label: string;
+}
+
+/**
+ * Build the calendar settings view model in a single pass: every calendar as a
+ * dropdown row (with the active one flagged), and the non-builtin calendars as
+ * the deletable imported list.
+ *
+ * @param calendars - The registry entries as `[id, registration]` pairs.
+ * @param activeId - The id of the active calendar.
+ * @param localize - Resolves a label localization key to its display string.
+ * @returns The dropdown rows and the imported-calendar rows.
+ */
+export function buildCalendarViewModel(
+    calendars: Iterable<[string, CalendarRegEntry]>,
+    activeId: string,
+    localize: (key: string) => string,
+): { calendars: CalendarRow[]; imported: ImportedCalendarRow[] } {
+    const rows: CalendarRow[] = [];
+    const imported: ImportedCalendarRow[] = [];
+    for (const [id, reg] of calendars) {
+        const label = localize(reg.label);
+        rows.push({ id, label, active: id === activeId });
+        if (!reg.builtin) imported.push({ id, label });
+    }
+    return { calendars: rows, imported };
+}

--- a/src/apps/logic/domain-manager-view.ts
+++ b/src/apps/logic/domain-manager-view.ts
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Foundry-free view-model builder for the Domain manager app
+ * ({@link DomainManagerApp}): group every registered domain by family, sort
+ * within each family, and compute the per-entry delete/override flags. Pure —
+ * the app supplies the already-resolved domain entries.
+ */
+
+import {
+    DOMAIN_FAMILY,
+    DomainFamilies,
+    domainFamilyLabels,
+    type DomainFamily,
+} from "@src/utils/constants";
+import type { DomainEntry } from "@src/core/SohlDomains";
+
+/** A domain entry augmented with the per-row UI flags. */
+export interface DomainRenderRow extends DomainEntry {
+    /** Whether the entry may be deleted through the UI (world entries only). */
+    canDelete: boolean;
+    /** Whether the entry shadows a system default. */
+    isOverride: boolean;
+}
+
+/** A family heading with its sorted, flagged domain rows. */
+export interface DomainRenderGroup {
+    /** The domain family. */
+    family: DomainFamily;
+    /** The localization key for the family heading. */
+    familyLabel: string;
+    /** The family's domain rows, sorted by sort then label. */
+    entries: DomainRenderRow[];
+}
+
+/**
+ * Group domain entries by family, sort each family's rows by `sort` then label,
+ * compute the delete/override flags, and drop empty families.
+ *
+ * A `world`-source entry is deletable; a `world` entry whose shortcode begins
+ * with `sohl.` is flagged as overriding a system default (the only way a GM can
+ * shadow a default through the UI).
+ *
+ * @param entries - Every registered domain entry.
+ * @returns The non-empty family groups, each with its sorted rows.
+ */
+export function buildDomainGroups(
+    entries: Iterable<DomainEntry>,
+): DomainRenderGroup[] {
+    const grouped = new Map<DomainFamily, DomainRenderRow[]>();
+    for (const family of DomainFamilies) {
+        grouped.set(family as DomainFamily, []);
+    }
+    for (const entry of entries) {
+        const list = grouped.get(entry.family);
+        if (!list) continue;
+        list.push({
+            ...entry,
+            canDelete: entry.source === "world",
+            isOverride:
+                entry.source === "world" && entry.shortcode.startsWith("sohl."),
+        });
+    }
+    for (const [, list] of grouped) {
+        list.sort((a, b) => {
+            if (a.sort !== b.sort) return a.sort - b.sort;
+            return a.label.localeCompare(b.label);
+        });
+    }
+
+    const groups: DomainRenderGroup[] = [];
+    for (const [family, rows] of grouped) {
+        if (rows.length === 0) continue;
+        const familyKey = Object.entries(DOMAIN_FAMILY).find(
+            ([, v]) => v === family,
+        )?.[0];
+        const familyLabel =
+            familyKey ?
+                domainFamilyLabels[familyKey as keyof typeof domainFamilyLabels]
+            :   family;
+        groups.push({ family, familyLabel, entries: rows });
+    }
+    return groups;
+}

--- a/src/core/SohlEventQueue.ts
+++ b/src/core/SohlEventQueue.ts
@@ -323,7 +323,6 @@ export class SohlEventQueue {
         const dispatched = new WeakSet<SohlSubscription>();
         const worldTime = ctx.worldTime;
 
-         
         while (true) {
             let next: SohlSubscription | undefined;
             let nextKey: string | undefined;

--- a/src/document/actor/foundry/BeingSheet.ts
+++ b/src/document/actor/foundry/BeingSheet.ts
@@ -15,13 +15,12 @@ import {
     SohlActor,
     SohlActorSheetBase,
 } from "@src/document/actor/foundry/SohlActor";
-import { fvttCallHook, fvttEnrichHTML } from "@src/core/FoundryHelpers";
+import { fvttCallHook } from "@src/core/FoundryHelpers";
 import {
     ITEM_KIND,
     MOVEMENT_MEDIUM,
     MovementMedium,
     movementMediumLabels,
-    STATUS_EFFECT,
     TRAIT_INTENSITY,
 } from "@src/utils/constants";
 import type { SohlItem } from "@src/document/item/foundry/SohlItem";
@@ -33,6 +32,14 @@ import {
     buildDamageCardData,
     type StrikeModeTestKind,
 } from "@src/document/actor/logic/combat-actions";
+import {
+    groupBySubType,
+    buildContainerTree,
+    buildStatusPills,
+    buildBodyPartLozenges,
+    clampHealthPct,
+    splitWeaponsByRange,
+} from "@src/document/actor/logic/being-sheet-view";
 import { SohlActionContext } from "@src/core/SohlActionContext";
 import { SimpleRoll } from "@src/utils/SimpleRoll";
 import { toFilePath } from "@src/utils/helpers";
@@ -41,6 +48,8 @@ import { SohlTokenDocument } from "@src/document/token/foundry/SohlTokenDocument
 type RenderContext =
     foundry.applications.api.DocumentSheetV2.RenderContext<SohlActor>;
 type RenderOptions = foundry.applications.api.DocumentSheetV2.RenderOptions;
+
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 
 /** @internal */
 export class BeingSheet extends SohlActorSheetBase {
@@ -549,48 +558,20 @@ export class BeingSheet extends SohlActorSheetBase {
             const legacyId = effect?.flags?.core?.statusId;
             if (legacyId) statuses.add(legacyId);
         }
-        const statusEffects = [
-            { id: STATUS_EFFECT.SLEEP, abbr: "SLP", label: "Sleep" },
-            { id: STATUS_EFFECT.PRONE, abbr: "PRN", label: "Prone" },
-            { id: STATUS_EFFECT.STUN, abbr: "STN", label: "Stun" },
-            {
-                id: STATUS_EFFECT.AURAL_SHOCK,
-                abbr: "ASHK",
-                label: "Aural Shock",
-            },
-            {
-                id: STATUS_EFFECT.INCAPACITATED,
-                abbr: "INC",
-                label: "Incapacitated",
-            },
-            {
-                id: STATUS_EFFECT.UNCONSCIOUS,
-                abbr: "UNC",
-                label: "Unconscious",
-            },
-            { id: STATUS_EFFECT.DEAD, abbr: "DED", label: "Dead" },
-        ].map((s) => ({ ...s, active: statuses.has(s.id) }));
+        const statusEffects = buildStatusPills(statuses);
 
         // Read-only body-location lozenges, sourced from the actor's Lineage body
         // structure (dynamic — varies by lineage).
         const lineageItem = (actor.itemTypes as any)?.[ITEM_KIND.LINEAGE]?.[0];
         const bodyStructure = (lineageItem?.logic as LineageLogic | undefined)
             ?.bodyStructure;
-        const bodyParts = (bodyStructure?.parts ?? []).map((p) => ({
-            shortcode: p.shortcode,
-        }));
-
-        // Health bar: `health.effective` is the current health percentage.
-        const healthPct = Math.max(
-            0,
-            Math.min(100, Math.round(logic?.health?.effective ?? 0)),
-        );
+        const bodyParts = buildBodyPartLozenges(bodyStructure);
 
         return Object.assign(context, {
             actorName: actor.name,
             actorImg: actor.img,
             health: logic?.health,
-            healthPct,
+            healthPct: clampHealthPct(logic?.health?.effective),
             shockState: logic?.shockState,
             statusEffects,
             bodyParts,
@@ -625,7 +606,9 @@ export class BeingSheet extends SohlActorSheetBase {
         const system = this.document.system as any;
         return Object.assign(context, {
             bioImage: system.bioImage,
-            descriptionHTML: await fvttEnrichHTML(system.description ?? ""),
+            descriptionHTML: await TextEditor.enrichHTML(
+                system.description ?? "",
+            ),
         });
     }
 
@@ -648,11 +631,10 @@ export class BeingSheet extends SohlActorSheetBase {
         }
 
         const traits = actor.itemTypes[ITEM_KIND.TRAIT] ?? [];
-        const traitGroups: StrictObject<SohlItem[]> = {};
-        for (const trait of traits) {
-            const subType = (trait.system as any).subType ?? "other";
-            (traitGroups[subType] ??= []).push(trait);
-        }
+        const traitGroups = groupBySubType(
+            traits,
+            (trait) => (trait.system as any).subType,
+        );
 
         const affiliations = actor.itemTypes[ITEM_KIND.AFFILIATION] ?? [];
 
@@ -689,7 +671,7 @@ export class BeingSheet extends SohlActorSheetBase {
             traitGroups,
             affiliations,
             movement,
-            biographyHTML: await fvttEnrichHTML(system.biography ?? ""),
+            biographyHTML: await TextEditor.enrichHTML(system.biography ?? ""),
         });
     }
 
@@ -705,19 +687,11 @@ export class BeingSheet extends SohlActorSheetBase {
         _options: RenderOptions,
     ): Promise<RenderContext> {
         const skills = this.document.itemTypes[ITEM_KIND.SKILL] ?? [];
-        const skillGroups: StrictObject<SohlItem[]> = {};
-
-        for (const skill of skills) {
-            const subType = (skill.system as any).subType ?? "other";
-            (skillGroups[subType] ??= []).push(skill);
-        }
-
-        // Sort skills within each group by name
-        for (const group of Object.values(skillGroups)) {
-            group.sort((a: SohlItem, b: SohlItem) =>
-                a.name.localeCompare(b.name),
-            );
-        }
+        const skillGroups = groupBySubType(
+            skills,
+            (skill) => (skill.system as any).subType,
+            (a, b) => a.name.localeCompare(b.name),
+        );
 
         return Object.assign(context, { skillGroups });
     }
@@ -737,23 +711,12 @@ export class BeingSheet extends SohlActorSheetBase {
         const actor = this.document;
         const logic = actor.logic as BeingLogic;
 
-        // Weapons with their strike mode domain objects
+        // Weapons split into melee/missile by their strike mode domain objects
         const weapons = actor.itemTypes[ITEM_KIND.WEAPONGEAR] ?? [];
-        const meleeWeapons: any[] = [];
-        const missileWeapons: any[] = [];
-
-        for (const weapon of weapons) {
-            const weaponLogic = weapon.logic as any;
-            const allModes = weaponLogic?.strikeModes ?? [];
-            const melee = allModes.filter((sm: any) => sm.isMelee);
-            const missile = allModes.filter((sm: any) => sm.isMissile);
-            if (melee.length > 0) {
-                meleeWeapons.push({ weapon, strikeModes: melee });
-            }
-            if (missile.length > 0) {
-                missileWeapons.push({ weapon, strikeModes: missile });
-            }
-        }
+        const { meleeWeapons, missileWeapons } = splitWeaponsByRange(
+            weapons,
+            (weapon) => (weapon.logic as any)?.strikeModes ?? [],
+        );
 
         // Combat techniques with their strike mode domain objects
         const combatTechniques = (
@@ -796,11 +759,10 @@ export class BeingSheet extends SohlActorSheetBase {
         const afflictions = actor.itemTypes[ITEM_KIND.AFFLICTION] ?? [];
 
         // Group afflictions by subType
-        const afflictionGroups: StrictObject<SohlItem[]> = {};
-        for (const affliction of afflictions) {
-            const subType = (affliction.system as any).subType ?? "other";
-            (afflictionGroups[subType] ??= []).push(affliction);
-        }
+        const afflictionGroups = groupBySubType(
+            afflictions,
+            (affliction) => (affliction.system as any).subType,
+        );
 
         return Object.assign(context, {
             traumas,
@@ -824,19 +786,17 @@ export class BeingSheet extends SohlActorSheetBase {
 
         // Mysteries grouped by subType
         const mysteries = actor.itemTypes[ITEM_KIND.MYSTERY] ?? [];
-        const mysteryGroups: StrictObject<SohlItem[]> = {};
-        for (const mystery of mysteries) {
-            const subType = (mystery.system as any).subType ?? "other";
-            (mysteryGroups[subType] ??= []).push(mystery);
-        }
+        const mysteryGroups = groupBySubType(
+            mysteries,
+            (mystery) => (mystery.system as any).subType,
+        );
 
         // Mystical abilities grouped by subType
         const abilities = actor.itemTypes[ITEM_KIND.MYSTICALABILITY] ?? [];
-        const abilityGroups: StrictObject<SohlItem[]> = {};
-        for (const ability of abilities) {
-            const subType = (ability.system as any).subType ?? "other";
-            (abilityGroups[subType] ??= []).push(ability);
-        }
+        const abilityGroups = groupBySubType(
+            abilities,
+            (ability) => (ability.system as any).subType,
+        );
 
         return Object.assign(context, {
             mysteryGroups,
@@ -858,14 +818,10 @@ export class BeingSheet extends SohlActorSheetBase {
     ): Promise<RenderContext> {
         const actor = this.document;
 
-        // Build container hierarchy
-        const containers: any[] = [];
         const containerGear = actor.itemTypes[ITEM_KIND.CONTAINERGEAR] ?? [];
 
-        // Virtual "On Body" container for ungrouped gear
-        const onBodyItems: SohlItem[] = [];
-
-        // Collect all gear items
+        // Collect all gear items (containers themselves included, so a
+        // top-level container appears both as a node and under "On Body").
         const gearTypes = [
             ITEM_KIND.ARMORGEAR,
             ITEM_KIND.WEAPONGEAR,
@@ -879,29 +835,12 @@ export class BeingSheet extends SohlActorSheetBase {
             allGear.push(...(actor.itemTypes[type] ?? []));
         }
 
-        const containerIds = new Set(containerGear.map((c: SohlItem) => c.id));
-
-        // Build a map of containerId → items inside that container
-        const containerContents = new Map<string, SohlItem[]>();
-        for (const item of allGear) {
-            const containerId = (item.system as any).containerId;
-            if (containerId && containerIds.has(containerId)) {
-                const list = containerContents.get(containerId) ?? [];
-                list.push(item);
-                containerContents.set(containerId, list);
-            } else {
-                // Not in any container — goes to "On Body"
-                onBodyItems.push(item);
-            }
-        }
-
-        // Build container entries with their contents
-        for (const container of containerGear) {
-            containers.push({
-                container,
-                items: containerContents.get(container.id!) ?? [],
-            });
-        }
+        const { containers, onBodyItems } = buildContainerTree(
+            containerGear,
+            allGear,
+            (item) => item.id,
+            (item) => (item.system as any).containerId,
+        );
 
         return Object.assign(context, {
             containers,

--- a/src/document/actor/logic/being-sheet-view.ts
+++ b/src/document/actor/logic/being-sheet-view.ts
@@ -1,0 +1,256 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Foundry-free view-model builders for the Being actor sheet.
+ *
+ * These are the pure data-shaping helpers behind {@link BeingSheet}'s
+ * `_prepare*Context` methods: grouping, container-hierarchy assembly, status
+ * pill construction, body-part lozenges, the health-bar clamp, and the
+ * melee/missile weapon split. They take accessor callbacks and minimal
+ * structural inputs (never Foundry document types), so they run — and are
+ * unit-tested — without Foundry. The sheet keeps the Foundry-facing work
+ * (reading collections, enrichment, hooks) and delegates the shaping here.
+ */
+
+import { STATUS_EFFECT } from "@src/utils/constants";
+
+/* -------------------------------------------- */
+/*  Grouping                                    */
+/* -------------------------------------------- */
+
+/** The subtype bucket used when an item declares no subtype. */
+const DEFAULT_SUBTYPE = "other";
+
+/**
+ * Group items into buckets keyed by their subtype, optionally sorting within
+ * each bucket. Items whose `getSubType` yields an empty/`undefined` value fall
+ * into the `"other"` bucket. Insertion order is preserved within a bucket
+ * unless `compare` is supplied.
+ *
+ * @param items - The items to group.
+ * @param getSubType - Derives an item's subtype key.
+ * @param compare - Optional within-bucket sort comparator.
+ * @returns A map of subtype key → items in that bucket.
+ */
+export function groupBySubType<T>(
+    items: readonly T[],
+    getSubType: (item: T) => string | undefined,
+    compare?: (a: T, b: T) => number,
+): Record<string, T[]> {
+    const groups: Record<string, T[]> = {};
+    for (const item of items) {
+        const subType = getSubType(item) || DEFAULT_SUBTYPE;
+        (groups[subType] ??= []).push(item);
+    }
+    if (compare) {
+        for (const bucket of Object.values(groups)) {
+            bucket.sort(compare);
+        }
+    }
+    return groups;
+}
+
+/* -------------------------------------------- */
+/*  Gear container hierarchy                     */
+/* -------------------------------------------- */
+
+/** A container paired with the gear items it holds. */
+export interface ContainerNode<T> {
+    /** The container item. */
+    container: T;
+    /** The gear items nested inside the container. */
+    items: T[];
+}
+
+/** The result of {@link buildContainerTree}: containers plus loose gear. */
+export interface ContainerTree<T> {
+    /** Every container with its resolved contents, in input order. */
+    containers: ContainerNode<T>[];
+    /** Gear not held by any known container — the virtual "On Body" list. */
+    onBodyItems: T[];
+}
+
+/**
+ * Build the gear container hierarchy: route each gear item into the container
+ * named by its `containerId`, or into the virtual "On Body" list when its
+ * `containerId` is empty or names no known container.
+ *
+ * `allGear` is expected to include the containers themselves (as in the sheet),
+ * so a top-level container appears both as a {@link ContainerNode} and in
+ * `onBodyItems` — matching the existing render behavior.
+ *
+ * @param containers - The container items, in display order.
+ * @param allGear - Every gear item (including containers) to place.
+ * @param getId - Resolves a container's id.
+ * @param getContainerId - Resolves the container id a gear item belongs to.
+ * @returns The containers with their contents and the "On Body" list.
+ */
+export function buildContainerTree<T>(
+    containers: readonly T[],
+    allGear: readonly T[],
+    getId: (item: T) => string | null | undefined,
+    getContainerId: (item: T) => string | null | undefined,
+): ContainerTree<T> {
+    const containerIds = new Set(
+        containers.map((c) => getId(c)).filter((id): id is string => !!id),
+    );
+
+    const contents = new Map<string, T[]>();
+    const onBodyItems: T[] = [];
+    for (const item of allGear) {
+        const containerId = getContainerId(item);
+        if (containerId && containerIds.has(containerId)) {
+            const list = contents.get(containerId) ?? [];
+            list.push(item);
+            contents.set(containerId, list);
+        } else {
+            onBodyItems.push(item);
+        }
+    }
+
+    const nodes: ContainerNode<T>[] = containers.map((container) => ({
+        container,
+        items: contents.get(getId(container) ?? "") ?? [],
+    }));
+
+    return { containers: nodes, onBodyItems };
+}
+
+/* -------------------------------------------- */
+/*  Header: status pills, lozenges, health       */
+/* -------------------------------------------- */
+
+/** A header status pill: its status id, labels, and active state. */
+export interface StatusPill {
+    /** The registered status-effect id (e.g. Foundry's `stun`). */
+    id: string;
+    /** Short label rendered on the pill. */
+    abbr: string;
+    /** Tooltip label. */
+    label: string;
+    /** Whether the status is currently active on the actor. */
+    active: boolean;
+}
+
+/**
+ * The fixed roster of header status pills, in display order. `id` must match a
+ * registered status (Foundry's id is `stun`, not `stunned`); `abbr` is the
+ * short label rendered, `label` is the tooltip.
+ */
+const STATUS_PILL_DEFS: readonly Omit<StatusPill, "active">[] = [
+    { id: STATUS_EFFECT.SLEEP, abbr: "SLP", label: "Sleep" },
+    { id: STATUS_EFFECT.PRONE, abbr: "PRN", label: "Prone" },
+    { id: STATUS_EFFECT.STUN, abbr: "STN", label: "Stun" },
+    { id: STATUS_EFFECT.AURAL_SHOCK, abbr: "ASHK", label: "Aural Shock" },
+    { id: STATUS_EFFECT.INCAPACITATED, abbr: "INC", label: "Incapacitated" },
+    { id: STATUS_EFFECT.UNCONSCIOUS, abbr: "UNC", label: "Unconscious" },
+    { id: STATUS_EFFECT.DEAD, abbr: "DED", label: "Dead" },
+];
+
+/**
+ * Build the header status pills, stamping each with whether its status id is
+ * present in the active set.
+ *
+ * @param activeStatusIds - The status ids currently active on the actor.
+ * @returns The status pills, in display order.
+ */
+export function buildStatusPills(
+    activeStatusIds: ReadonlySet<string>,
+): StatusPill[] {
+    return STATUS_PILL_DEFS.map((def) => ({
+        ...def,
+        active: activeStatusIds.has(def.id),
+    }));
+}
+
+/** A read-only body-location lozenge. */
+export interface BodyPartLozenge {
+    /** The body-part shortcode. */
+    shortcode: string;
+}
+
+/**
+ * Build the read-only body-location lozenges from a lineage body structure.
+ *
+ * @param bodyStructure - The actor's lineage body structure, or `undefined`.
+ * @returns One lozenge per body part, or an empty array when none.
+ */
+export function buildBodyPartLozenges(
+    bodyStructure: { parts?: readonly { shortcode: string }[] } | undefined,
+): BodyPartLozenge[] {
+    return (bodyStructure?.parts ?? []).map((p) => ({
+        shortcode: p.shortcode,
+    }));
+}
+
+/**
+ * Clamp a raw health value to an integer percentage in `[0, 100]` for the
+ * health bar. A missing value clamps to `0`.
+ *
+ * @param value - The raw health percentage.
+ * @returns An integer in `[0, 100]`.
+ */
+export function clampHealthPct(value: number | null | undefined): number {
+    return Math.max(0, Math.min(100, Math.round(value ?? 0)));
+}
+
+/* -------------------------------------------- */
+/*  Combat: melee/missile weapon split           */
+/* -------------------------------------------- */
+
+/** A weapon paired with a subset of its strike modes. */
+export interface WeaponStrikeGroup<W, SM> {
+    /** The weapon item. */
+    weapon: W;
+    /** The weapon's strike modes for this range band. */
+    strikeModes: SM[];
+}
+
+/** The result of {@link splitWeaponsByRange}. */
+export interface WeaponRangeSplit<W, SM> {
+    /** Weapons that have at least one melee strike mode. */
+    meleeWeapons: WeaponStrikeGroup<W, SM>[];
+    /** Weapons that have at least one missile strike mode. */
+    missileWeapons: WeaponStrikeGroup<W, SM>[];
+}
+
+/**
+ * Partition weapons into melee and missile lists by their strike modes. A
+ * weapon appears in a list only when it has at least one mode for that range
+ * band, and a weapon with both kinds appears in both lists (each with only the
+ * matching modes).
+ *
+ * @param weapons - The weapon items.
+ * @param getStrikeModes - Resolves a weapon's strike modes.
+ * @returns The melee and missile weapon groups, in input order.
+ */
+export function splitWeaponsByRange<
+    W,
+    SM extends { isMelee?: boolean; isMissile?: boolean },
+>(
+    weapons: readonly W[],
+    getStrikeModes: (weapon: W) => readonly SM[],
+): WeaponRangeSplit<W, SM> {
+    const meleeWeapons: WeaponStrikeGroup<W, SM>[] = [];
+    const missileWeapons: WeaponStrikeGroup<W, SM>[] = [];
+    for (const weapon of weapons) {
+        const modes = getStrikeModes(weapon);
+        const melee = modes.filter((sm) => sm.isMelee);
+        const missile = modes.filter((sm) => sm.isMissile);
+        if (melee.length > 0) meleeWeapons.push({ weapon, strikeModes: melee });
+        if (missile.length > 0)
+            missileWeapons.push({ weapon, strikeModes: missile });
+    }
+    return { meleeWeapons, missileWeapons };
+}

--- a/src/document/effect/foundry/SohlActiveEffectSheet.ts
+++ b/src/document/effect/foundry/SohlActiveEffectSheet.ts
@@ -11,9 +11,14 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { ACTIVE_EFFECT_SCOPE, ITEM_METADATA } from "@src/utils/constants";
+import { ACTIVE_EFFECT_SCOPE } from "@src/utils/constants";
 import type { SohlActor } from "@src/document/actor/foundry/SohlActor";
 import type { SohlItem } from "@src/document/item/foundry/SohlItem";
+import {
+    buildChangeTypesMap,
+    resolveEffectMetadataType,
+    resolveEffectKeyChoices,
+} from "@src/document/effect/logic/effect-sheet-view";
 
 const BaseAEConfig = foundry.applications.sheets.ActiveEffectConfig;
 
@@ -89,17 +94,8 @@ export class SohlActiveEffectSheet extends BaseAEConfig {
             case "changes": {
                 // v14: Use ActiveEffect.CHANGE_TYPES (string-keyed registry)
                 // instead of deprecated CONST.ACTIVE_EFFECT_MODES (numeric)
-                partContext.changeTypes = Object.entries(
-                    (ActiveEffect as any).CHANGE_TYPES ?? {},
-                ).reduce(
-                    (
-                        types: StrictObject<string>,
-                        [key, config]: [string, any],
-                    ) => {
-                        types[key] = sohl.i18n.localize(config.label ?? key);
-                        return types;
-                    },
-                    {},
+                partContext.changeTypes = buildChangeTypesMap(
+                    (ActiveEffect as any).CHANGE_TYPES,
                 );
                 // The `key` dropdown should reflect the EFFECT_KEY namespace
                 // determined by `system.scope`:
@@ -107,21 +103,13 @@ export class SohlActiveEffectSheet extends BaseAEConfig {
                 //   - "actor": the owning actor's type
                 //   - <itemKind>: that item kind's metadata
                 const scope = (document as any).system?.scope;
-                let metadataType: string;
-                if (scope === ACTIVE_EFFECT_SCOPE.THIS) {
-                    metadataType = document.parent?.type ?? document.type;
-                } else if (scope === ACTIVE_EFFECT_SCOPE.ACTOR) {
-                    metadataType = (document as any).actor?.type ?? "";
-                } else {
-                    metadataType = scope ?? "";
-                }
-                const itemData =
-                    metadataType in ITEM_METADATA ?
-                        ITEM_METADATA[
-                            metadataType as keyof typeof ITEM_METADATA
-                        ]
-                    :   undefined;
-                partContext.keyChoices = (itemData as any)?.KeyChoices || [];
+                const metadataType = resolveEffectMetadataType(
+                    scope,
+                    document.type,
+                    document.parent?.type,
+                    (document as any).actor?.type,
+                );
+                partContext.keyChoices = resolveEffectKeyChoices(metadataType);
                 // Surface the scope to the template so the strikeModePredicate
                 // row can conditionally render for weapongear scope + sm: keys.
                 partContext.scope = scope;

--- a/src/document/effect/logic/effect-sheet-view.ts
+++ b/src/document/effect/logic/effect-sheet-view.ts
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Foundry-free view-model helpers for the Active Effect editor
+ * (`SohlActiveEffectSheet`): the change-type label map and the scope → effect-key
+ * namespace resolution behind the Changes tab. They take plain inputs (never
+ * Foundry document types) so they run — and are unit-tested — without Foundry.
+ */
+
+import { ACTIVE_EFFECT_SCOPE, ITEM_METADATA } from "@src/utils/constants";
+
+/**
+ * Build the localized change-type label map for the change `mode` dropdown from
+ * Foundry's `ActiveEffect.CHANGE_TYPES` registry. Each entry is localized by its
+ * `label`, falling back to the registry key when it has none.
+ *
+ * @param changeTypes - The `ActiveEffect.CHANGE_TYPES` registry, or nullish.
+ * @returns A map of change-type key → localized label.
+ */
+export function buildChangeTypesMap(
+    changeTypes:
+        | Record<string, { label?: string } | undefined>
+        | null
+        | undefined,
+): Record<string, string> {
+    const types: Record<string, string> = {};
+    for (const [key, config] of Object.entries(changeTypes ?? {})) {
+        types[key] = sohl.i18n.localize(config?.label ?? key);
+    }
+    return types;
+}
+
+/**
+ * Resolve the effect-key namespace an active effect's `key` dropdown should draw
+ * from, based on its `system.scope`:
+ *
+ * - `"this"` → the parent document's own type (falling back to the effect's type),
+ * - `"actor"` → the owning actor's type,
+ * - otherwise → the scope value itself (an item kind).
+ *
+ * @param scope - The effect's `system.scope`, or `undefined`.
+ * @param documentType - The effect document's own type.
+ * @param parentType - The parent document's type, or `undefined`.
+ * @param actorType - The owning actor's type, or `undefined`.
+ * @returns The resolved metadata type (item kind / actor type).
+ */
+export function resolveEffectMetadataType(
+    scope: string | undefined,
+    documentType: string,
+    parentType: string | undefined,
+    actorType: string | undefined,
+): string {
+    if (scope === ACTIVE_EFFECT_SCOPE.THIS) {
+        return parentType ?? documentType;
+    }
+    if (scope === ACTIVE_EFFECT_SCOPE.ACTOR) {
+        return actorType ?? "";
+    }
+    return scope ?? "";
+}
+
+/**
+ * The `key`-dropdown choices for a resolved metadata type, read from
+ * {@link ITEM_METADATA}. Unknown types (e.g. an actor type) have no choices.
+ *
+ * @param metadataType - The metadata type from {@link resolveEffectMetadataType}.
+ * @returns The key choices, or an empty array when the type has none.
+ */
+export function resolveEffectKeyChoices(metadataType: string): unknown[] {
+    const itemData =
+        metadataType in ITEM_METADATA ?
+            ITEM_METADATA[metadataType as keyof typeof ITEM_METADATA]
+        :   undefined;
+    return (
+        (itemData as { KeyChoices?: unknown[] } | undefined)?.KeyChoices ?? []
+    );
+}

--- a/src/document/item/foundry/SohlItem.ts
+++ b/src/document/item/foundry/SohlItem.ts
@@ -22,6 +22,12 @@ import { fvttCallHook } from "@src/core/FoundryHelpers";
 import type { SohlTriggerContext } from "@src/core/SohlEventTrigger";
 import { isScriptActionMutationAllowed } from "@src/domain/action/SohlAction";
 import { GearLogic } from "../logic/GearLogic";
+import {
+    localizeSubType,
+    keyTransferredEffects,
+    findSimilarItem,
+    type ItemMatchKey,
+} from "@src/document/item/logic/item-sheet-view";
 const { HTMLField } = foundry.data.fields;
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
 type RenderContext =
@@ -617,14 +623,8 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
     ): Promise<RenderContext> {
         const system = this.document.system as any;
         const subType = system.subType ?? "";
-        let subTypeLabel = "";
-        if (subType) {
-            // Try to localize the subtype using the type's localization prefix
-            const kind = system.constructor?.kind ?? this.document.type;
-            const locKey = `SOHL.${kind}.SubType.${subType}`;
-            const localized = sohl.i18n.localize(locKey);
-            subTypeLabel = localized !== locKey ? localized : subType;
-        }
+        const kind = system.constructor?.kind ?? this.document.type;
+        const subTypeLabel = localizeSubType(subType, kind);
         return Object.assign(context, {
             itemName: this.document.name,
             itemImg: this.document.img,
@@ -700,15 +700,9 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
         _options: RenderOptions,
     ): Promise<RenderContext> {
         const effects = (this.document as any).effects?.contents ?? [];
-        const trxEffects: PlainObject = {};
-        const transferredEffects = (this.document as any).transferredEffects;
-        if (transferredEffects) {
-            for (const effect of transferredEffects) {
-                if (!effect.disabled) {
-                    trxEffects[effect.id] = effect;
-                }
-            }
-        }
+        const trxEffects = keyTransferredEffects(
+            (this.document as any).transferredEffects,
+        );
         return Object.assign(context, { effects, trxEffects });
     }
 
@@ -750,12 +744,10 @@ export abstract class SohlItemSheetBase extends SohlItemSheetBase_Base {
         const toCreate = [];
         for (let itemData of itemList) {
             // Determine if a similar item exists
-            let similarItem = this.actor.items.find(
-                (it: SohlItem) =>
-                    it.name === itemData.name &&
-                    it.type === itemData.type &&
-                    (it.system as any).subType === itemData.system.subType,
-            );
+            const similarItem = findSimilarItem(
+                itemData as ItemMatchKey,
+                this.actor.items as any,
+            ) as SohlItem | undefined;
 
             if (similarItem) {
                 const confirm = await Dialog.confirm({

--- a/src/document/item/logic/item-sheet-view.ts
+++ b/src/document/item/logic/item-sheet-view.ts
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Foundry-free view-model helpers shared by the item sheets (`SohlItemSheetBase`).
+ *
+ * These are the pure pieces behind the base item sheet's context builders and
+ * drop handling: subtype-label localization, transferred-effect keying, and the
+ * "is there already a similar item?" match used by overwrite-on-drop. They take
+ * minimal structural inputs (never Foundry document types) so they run — and are
+ * unit-tested — without Foundry; the sheet keeps the Foundry-facing work
+ * (collections, dialogs, document mutation).
+ */
+
+/**
+ * Localize an item's subtype label, falling back to the raw subtype value when
+ * no localization entry exists.
+ *
+ * @param subType - The item's subtype value (empty when the item has none).
+ * @param kind - The item kind, used as the localization-key prefix.
+ * @returns The localized label, the raw subtype if unlocalized, or `""` when
+ *   there is no subtype.
+ */
+export function localizeSubType(subType: string, kind: string): string {
+    if (!subType) return "";
+    const locKey = `SOHL.${kind}.SubType.${subType}`;
+    const localized = sohl.i18n.localize(locKey);
+    return localized !== locKey ? localized : subType;
+}
+
+/**
+ * Key an item's transferred active effects by id, excluding disabled effects.
+ *
+ * @param transferredEffects - The transferred effects, or `null`/`undefined`.
+ * @returns A map of effect id → effect for each enabled effect, in input order.
+ */
+export function keyTransferredEffects<
+    T extends { id: string; disabled?: boolean },
+>(transferredEffects: Iterable<T> | null | undefined): Record<string, T> {
+    const trxEffects: Record<string, T> = {};
+    for (const effect of transferredEffects ?? []) {
+        if (!effect.disabled) trxEffects[effect.id] = effect;
+    }
+    return trxEffects;
+}
+
+/** The identifying fields used to match a dropped item against existing ones. */
+export interface ItemMatchKey {
+    /** The item name. */
+    name: string;
+    /** The item type. */
+    type: string;
+    /** The item system data, carrying its subtype. */
+    system: { subType?: unknown };
+}
+
+/**
+ * Find an existing item that matches the dropped item by name, type, and
+ * subtype — the "similar item" an overwrite-on-drop would replace.
+ *
+ * @param itemData - The dropped item's identifying fields.
+ * @param actorItems - The actor's existing items.
+ * @returns The first matching item, or `undefined` when none match.
+ */
+export function findSimilarItem<T extends ItemMatchKey>(
+    itemData: ItemMatchKey,
+    actorItems: Iterable<T>,
+): T | undefined {
+    for (const it of actorItems) {
+        if (
+            it.name === itemData.name &&
+            it.type === itemData.type &&
+            it.system.subType === itemData.system.subType
+        ) {
+            return it;
+        }
+    }
+    return undefined;
+}

--- a/tests/actor/being-sheet-view.test.ts
+++ b/tests/actor/being-sheet-view.test.ts
@@ -1,0 +1,232 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+    groupBySubType,
+    buildContainerTree,
+    buildStatusPills,
+    buildBodyPartLozenges,
+    clampHealthPct,
+    splitWeaponsByRange,
+} from "@src/document/actor/logic/being-sheet-view";
+import { STATUS_EFFECT } from "@src/utils/constants";
+
+describe("being-sheet-view", () => {
+    describe("groupBySubType", () => {
+        interface Item {
+            subType?: string;
+            name: string;
+        }
+        const sub = (i: Item) => i.subType;
+
+        it("groups items by their subtype key", () => {
+            const a: Item = { subType: "social", name: "A" };
+            const b: Item = { subType: "physical", name: "B" };
+            const c: Item = { subType: "social", name: "C" };
+            const groups = groupBySubType([a, b, c], sub);
+            expect(groups).toEqual({ social: [a, c], physical: [b] });
+        });
+
+        it("buckets items with no subtype under 'other'", () => {
+            const a: Item = { name: "A" };
+            const b: Item = { subType: "", name: "B" };
+            const groups = groupBySubType([a, b], sub);
+            expect(groups).toEqual({ other: [a, b] });
+        });
+
+        it("preserves insertion order within a bucket without a comparator", () => {
+            const items: Item[] = [
+                { subType: "s", name: "Zed" },
+                { subType: "s", name: "Ana" },
+            ];
+            expect(groupBySubType(items, sub).s).toEqual(items);
+        });
+
+        it("sorts within each bucket when a comparator is given", () => {
+            const zed: Item = { subType: "s", name: "Zed" };
+            const ana: Item = { subType: "s", name: "Ana" };
+            const groups = groupBySubType([zed, ana], sub, (x, y) =>
+                x.name.localeCompare(y.name),
+            );
+            expect(groups.s).toEqual([ana, zed]);
+        });
+
+        it("returns an empty object for empty input", () => {
+            expect(groupBySubType([] as Item[], sub)).toEqual({});
+        });
+    });
+
+    describe("buildContainerTree", () => {
+        interface Gear {
+            id: string;
+            containerId?: string | null;
+        }
+        const id = (i: Gear) => i.id;
+        const cid = (i: Gear) => i.containerId;
+
+        it("nests gear under its container and leaves loose gear On Body", () => {
+            const pack: Gear = { id: "pack" };
+            const sword: Gear = { id: "sword", containerId: "pack" };
+            const ring: Gear = { id: "ring", containerId: null };
+            const tree = buildContainerTree(
+                [pack],
+                [pack, sword, ring],
+                id,
+                cid,
+            );
+            expect(tree.containers).toEqual([
+                { container: pack, items: [sword] },
+            ]);
+            // pack has no containerId → On Body; ring has none → On Body.
+            expect(tree.onBodyItems).toEqual([pack, ring]);
+        });
+
+        it("routes gear with an unknown containerId to On Body", () => {
+            const sword: Gear = { id: "sword", containerId: "ghost" };
+            const tree = buildContainerTree([] as Gear[], [sword], id, cid);
+            expect(tree.containers).toEqual([]);
+            expect(tree.onBodyItems).toEqual([sword]);
+        });
+
+        it("yields an empty contents list for a container with no items", () => {
+            const pack: Gear = { id: "pack" };
+            const tree = buildContainerTree([pack], [pack], id, cid);
+            expect(tree.containers).toEqual([{ container: pack, items: [] }]);
+        });
+
+        it("nests a container inside another container", () => {
+            const pack: Gear = { id: "pack" };
+            const pouch: Gear = { id: "pouch", containerId: "pack" };
+            const tree = buildContainerTree(
+                [pack, pouch],
+                [pack, pouch],
+                id,
+                cid,
+            );
+            const packNode = tree.containers.find((n) => n.container === pack)!;
+            expect(packNode.items).toEqual([pouch]);
+            // pouch is nested, not On Body; pack (no containerId) is On Body.
+            expect(tree.onBodyItems).toEqual([pack]);
+        });
+    });
+
+    describe("buildStatusPills", () => {
+        it("returns the seven pills in display order", () => {
+            const pills = buildStatusPills(new Set());
+            expect(pills.map((p) => p.id)).toEqual([
+                STATUS_EFFECT.SLEEP,
+                STATUS_EFFECT.PRONE,
+                STATUS_EFFECT.STUN,
+                STATUS_EFFECT.AURAL_SHOCK,
+                STATUS_EFFECT.INCAPACITATED,
+                STATUS_EFFECT.UNCONSCIOUS,
+                STATUS_EFFECT.DEAD,
+            ]);
+        });
+
+        it("marks only the active status ids active", () => {
+            const pills = buildStatusPills(
+                new Set([STATUS_EFFECT.STUN, STATUS_EFFECT.DEAD]),
+            );
+            const active = pills.filter((p) => p.active).map((p) => p.id);
+            expect(active).toEqual([STATUS_EFFECT.STUN, STATUS_EFFECT.DEAD]);
+        });
+
+        it("carries abbr and label for each pill", () => {
+            const stun = buildStatusPills(new Set()).find(
+                (p) => p.id === STATUS_EFFECT.STUN,
+            )!;
+            expect(stun).toMatchObject({ abbr: "STN", label: "Stun" });
+        });
+    });
+
+    describe("buildBodyPartLozenges", () => {
+        it("maps each body part to its shortcode", () => {
+            const bodyStructure = {
+                parts: [{ shortcode: "HEAD" }, { shortcode: "TORSO" }],
+            };
+            expect(buildBodyPartLozenges(bodyStructure)).toEqual([
+                { shortcode: "HEAD" },
+                { shortcode: "TORSO" },
+            ]);
+        });
+
+        it("returns an empty array for undefined or empty structure", () => {
+            expect(buildBodyPartLozenges(undefined)).toEqual([]);
+            expect(buildBodyPartLozenges({})).toEqual([]);
+            expect(buildBodyPartLozenges({ parts: [] })).toEqual([]);
+        });
+    });
+
+    describe("clampHealthPct", () => {
+        it("clamps below 0 and above 100", () => {
+            expect(clampHealthPct(-25)).toBe(0);
+            expect(clampHealthPct(150)).toBe(100);
+        });
+
+        it("rounds to the nearest integer", () => {
+            expect(clampHealthPct(42.4)).toBe(42);
+            expect(clampHealthPct(42.6)).toBe(43);
+        });
+
+        it("treats null/undefined as 0", () => {
+            expect(clampHealthPct(undefined)).toBe(0);
+            expect(clampHealthPct(null)).toBe(0);
+        });
+    });
+
+    describe("splitWeaponsByRange", () => {
+        const modes = (w: {
+            strikeModes: { isMelee?: boolean; isMissile?: boolean }[];
+        }) => w.strikeModes;
+
+        it("places a melee-only weapon in the melee list", () => {
+            const w = { strikeModes: [{ isMelee: true }] };
+            const split = splitWeaponsByRange([w], modes);
+            expect(split.meleeWeapons).toEqual([
+                { weapon: w, strikeModes: w.strikeModes },
+            ]);
+            expect(split.missileWeapons).toEqual([]);
+        });
+
+        it("places a missile-only weapon in the missile list", () => {
+            const w = { strikeModes: [{ isMissile: true }] };
+            const split = splitWeaponsByRange([w], modes);
+            expect(split.missileWeapons).toEqual([
+                { weapon: w, strikeModes: w.strikeModes },
+            ]);
+            expect(split.meleeWeapons).toEqual([]);
+        });
+
+        it("places a dual-range weapon in both lists with only matching modes", () => {
+            const melee = { isMelee: true };
+            const missile = { isMissile: true };
+            const w = { strikeModes: [melee, missile] };
+            const split = splitWeaponsByRange([w], modes);
+            expect(split.meleeWeapons).toEqual([
+                { weapon: w, strikeModes: [melee] },
+            ]);
+            expect(split.missileWeapons).toEqual([
+                { weapon: w, strikeModes: [missile] },
+            ]);
+        });
+
+        it("omits a weapon with neither range band", () => {
+            const w = { strikeModes: [{}] };
+            const split = splitWeaponsByRange([w], modes);
+            expect(split.meleeWeapons).toEqual([]);
+            expect(split.missileWeapons).toEqual([]);
+        });
+    });
+});

--- a/tests/apps/calendar-settings-view.test.ts
+++ b/tests/apps/calendar-settings-view.test.ts
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+    buildCalendarViewModel,
+    type CalendarRegEntry,
+} from "@src/apps/logic/calendar-settings-view";
+
+const upper = (key: string) => key.toUpperCase();
+
+const registry: [string, CalendarRegEntry][] = [
+    ["greg", { label: "greg", builtin: true }],
+    ["harn", { label: "harn", builtin: true }],
+    ["custom", { label: "custom", builtin: false }],
+];
+
+describe("calendar-settings-view", () => {
+    describe("buildCalendarViewModel", () => {
+        it("builds a dropdown row per calendar, localizing labels", () => {
+            const { calendars } = buildCalendarViewModel(
+                registry,
+                "harn",
+                upper,
+            );
+            expect(calendars).toEqual([
+                { id: "greg", label: "GREG", active: false },
+                { id: "harn", label: "HARN", active: true },
+                { id: "custom", label: "CUSTOM", active: false },
+            ]);
+        });
+
+        it("lists only non-builtin calendars as imported", () => {
+            const { imported } = buildCalendarViewModel(
+                registry,
+                "greg",
+                upper,
+            );
+            expect(imported).toEqual([{ id: "custom", label: "CUSTOM" }]);
+        });
+
+        it("marks no row active when the active id is unknown", () => {
+            const { calendars } = buildCalendarViewModel(
+                registry,
+                "none",
+                upper,
+            );
+            expect(calendars.some((c) => c.active)).toBe(false);
+        });
+
+        it("returns empty lists for an empty registry", () => {
+            const vm = buildCalendarViewModel([], "x", upper);
+            expect(vm).toEqual({ calendars: [], imported: [] });
+        });
+    });
+});

--- a/tests/apps/domain-manager-view.test.ts
+++ b/tests/apps/domain-manager-view.test.ts
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildDomainGroups } from "@src/apps/logic/domain-manager-view";
+import { DOMAIN_FAMILY, domainFamilyLabels } from "@src/utils/constants";
+import type { DomainEntry } from "@src/core/SohlDomains";
+
+function entry(over: Partial<DomainEntry>): DomainEntry {
+    return {
+        family: DOMAIN_FAMILY.ARCANE,
+        source: "system",
+        shortcode: "sohl.fire",
+        sort: 0,
+        label: "Fire",
+        ...over,
+    } as DomainEntry;
+}
+
+describe("domain-manager-view", () => {
+    describe("buildDomainGroups", () => {
+        it("groups entries under their family with the family label key", () => {
+            const groups = buildDomainGroups([
+                entry({ family: DOMAIN_FAMILY.ARCANE, label: "Fire" }),
+            ]);
+            expect(groups).toHaveLength(1);
+            expect(groups[0].family).toBe(DOMAIN_FAMILY.ARCANE);
+            expect(groups[0].familyLabel).toBe(domainFamilyLabels.ARCANE);
+            expect(groups[0].entries.map((e) => e.label)).toEqual(["Fire"]);
+        });
+
+        it("drops families with no entries", () => {
+            const groups = buildDomainGroups([
+                entry({ family: DOMAIN_FAMILY.DIVINE }),
+            ]);
+            expect(groups.map((g) => g.family)).toEqual([DOMAIN_FAMILY.DIVINE]);
+        });
+
+        it("sorts within a family by sort then label", () => {
+            const groups = buildDomainGroups([
+                entry({ label: "Zeta", sort: 1 }),
+                entry({ label: "Beta", sort: 1 }),
+                entry({ label: "Alpha", sort: 0 }),
+            ]);
+            expect(groups[0].entries.map((e) => e.label)).toEqual([
+                "Alpha",
+                "Beta",
+                "Zeta",
+            ]);
+        });
+
+        it("flags world entries as deletable and sohl.* world entries as overrides", () => {
+            const groups = buildDomainGroups([
+                entry({ source: "world", shortcode: "sohl.fire" }),
+                entry({ source: "world", shortcode: "world.custom" }),
+                entry({ source: "system", shortcode: "sohl.water" }),
+            ]);
+            const rows = groups[0].entries;
+            const byCode = (c: string) => rows.find((r) => r.shortcode === c)!;
+            expect(byCode("sohl.fire")).toMatchObject({
+                canDelete: true,
+                isOverride: true,
+            });
+            expect(byCode("world.custom")).toMatchObject({
+                canDelete: true,
+                isOverride: false,
+            });
+            expect(byCode("sohl.water")).toMatchObject({
+                canDelete: false,
+                isOverride: false,
+            });
+        });
+
+        it("returns an empty array for no entries", () => {
+            expect(buildDomainGroups([])).toEqual([]);
+        });
+    });
+});

--- a/tests/effect/effect-sheet-view.test.ts
+++ b/tests/effect/effect-sheet-view.test.ts
@@ -1,0 +1,122 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+    buildChangeTypesMap,
+    resolveEffectMetadataType,
+    resolveEffectKeyChoices,
+} from "@src/document/effect/logic/effect-sheet-view";
+import {
+    ACTIVE_EFFECT_SCOPE,
+    ITEM_KIND,
+    ITEM_METADATA,
+} from "@src/utils/constants";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("effect-sheet-view", () => {
+    describe("buildChangeTypesMap", () => {
+        it("localizes each entry by its label", () => {
+            vi.spyOn(sohl.i18n, "localize").mockImplementation((key: string) =>
+                key === "EFFECT.Add" ? "Add" : key,
+            );
+            const map = buildChangeTypesMap({ add: { label: "EFFECT.Add" } });
+            expect(map).toEqual({ add: "Add" });
+        });
+
+        it("falls back to the registry key when an entry has no label", () => {
+            // Default stub returns the key unchanged.
+            expect(buildChangeTypesMap({ custom: {} })).toEqual({
+                custom: "custom",
+            });
+        });
+
+        it("returns an empty object for nullish input", () => {
+            expect(buildChangeTypesMap(null)).toEqual({});
+            expect(buildChangeTypesMap(undefined)).toEqual({});
+        });
+    });
+
+    describe("resolveEffectMetadataType", () => {
+        it("uses the parent type for 'this' scope", () => {
+            expect(
+                resolveEffectMetadataType(
+                    ACTIVE_EFFECT_SCOPE.THIS,
+                    "effect",
+                    "weapongear",
+                    "being",
+                ),
+            ).toBe("weapongear");
+        });
+
+        it("falls back to the document type for 'this' scope without a parent", () => {
+            expect(
+                resolveEffectMetadataType(
+                    ACTIVE_EFFECT_SCOPE.THIS,
+                    "effect",
+                    undefined,
+                    "being",
+                ),
+            ).toBe("effect");
+        });
+
+        it("uses the actor type for 'actor' scope", () => {
+            expect(
+                resolveEffectMetadataType(
+                    ACTIVE_EFFECT_SCOPE.ACTOR,
+                    "effect",
+                    "weapongear",
+                    "being",
+                ),
+            ).toBe("being");
+        });
+
+        it("returns the scope itself for an item-kind scope", () => {
+            expect(
+                resolveEffectMetadataType(
+                    ITEM_KIND.SKILL,
+                    "effect",
+                    undefined,
+                    undefined,
+                ),
+            ).toBe(ITEM_KIND.SKILL);
+        });
+
+        it("returns an empty string when scope is undefined", () => {
+            expect(
+                resolveEffectMetadataType(
+                    undefined,
+                    "effect",
+                    undefined,
+                    undefined,
+                ),
+            ).toBe("");
+        });
+    });
+
+    describe("resolveEffectKeyChoices", () => {
+        it("returns the metadata's key choices for a known item kind", () => {
+            expect(resolveEffectKeyChoices(ITEM_KIND.SKILL)).toBe(
+                ITEM_METADATA[ITEM_KIND.SKILL].KeyChoices,
+            );
+        });
+
+        it("returns an empty array for an unknown type", () => {
+            expect(resolveEffectKeyChoices("being")).toEqual([]);
+            expect(resolveEffectKeyChoices("")).toEqual([]);
+        });
+    });
+});

--- a/tests/item/item-sheet-view.test.ts
+++ b/tests/item/item-sheet-view.test.ts
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+    localizeSubType,
+    keyTransferredEffects,
+    findSimilarItem,
+    type ItemMatchKey,
+} from "@src/document/item/logic/item-sheet-view";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("item-sheet-view", () => {
+    describe("localizeSubType", () => {
+        it("returns an empty string when there is no subtype", () => {
+            expect(localizeSubType("", "skill")).toBe("");
+        });
+
+        it("returns the localized label when an entry exists", () => {
+            vi.spyOn(sohl.i18n, "localize").mockImplementation((key: string) =>
+                key === "SOHL.skill.SubType.social" ? "Social" : key,
+            );
+            expect(localizeSubType("social", "skill")).toBe("Social");
+        });
+
+        it("falls back to the raw subtype when unlocalized", () => {
+            // Default test stub returns the key unchanged → no localization.
+            expect(localizeSubType("social", "skill")).toBe("social");
+        });
+
+        it("builds the key from the kind prefix", () => {
+            const spy = vi.spyOn(sohl.i18n, "localize").mockReturnValue("X");
+            localizeSubType("ranged", "weapongear");
+            expect(spy).toHaveBeenCalledWith("SOHL.weapongear.SubType.ranged");
+        });
+    });
+
+    describe("keyTransferredEffects", () => {
+        it("keys enabled effects by id", () => {
+            const a = { id: "a", disabled: false };
+            const b = { id: "b" };
+            expect(keyTransferredEffects([a, b])).toEqual({ a, b });
+        });
+
+        it("excludes disabled effects", () => {
+            const a = { id: "a", disabled: true };
+            const b = { id: "b", disabled: false };
+            expect(keyTransferredEffects([a, b])).toEqual({ b });
+        });
+
+        it("returns an empty object for null/undefined input", () => {
+            expect(keyTransferredEffects(null)).toEqual({});
+            expect(keyTransferredEffects(undefined)).toEqual({});
+        });
+    });
+
+    describe("findSimilarItem", () => {
+        const make = (
+            name: string,
+            type: string,
+            subType?: unknown,
+        ): ItemMatchKey => ({ name, type, system: { subType } });
+
+        const items: ItemMatchKey[] = [
+            make("Sword", "weapongear", "melee"),
+            make("Dagger", "weapongear", "melee"),
+        ];
+
+        it("matches on name, type, and subtype together", () => {
+            const hit = findSimilarItem(
+                make("Dagger", "weapongear", "melee"),
+                items,
+            );
+            expect(hit).toBe(items[1]);
+        });
+
+        it("does not match when the subtype differs", () => {
+            expect(
+                findSimilarItem(make("Sword", "weapongear", "thrown"), items),
+            ).toBeUndefined();
+        });
+
+        it("does not match when the type differs", () => {
+            expect(
+                findSimilarItem(make("Sword", "miscgear", "melee"), items),
+            ).toBeUndefined();
+        });
+
+        it("returns undefined against an empty collection", () => {
+            expect(
+                findSimilarItem(make("Sword", "weapongear", "melee"), []),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/tests/purity/logic-imports.purity.ts
+++ b/tests/purity/logic-imports.purity.ts
@@ -61,6 +61,9 @@ const PURE_ZONES: Record<string, Record<string, () => Promise<unknown>>> = {
         "../../src/document/effect/logic/**/*.ts",
         { eager: false },
     ),
+    "apps logic layer": import.meta.glob("../../src/apps/logic/**/*.ts", {
+        eager: false,
+    }),
     "domain layer": import.meta.glob("../../src/domain/**/*.ts", {
         eager: false,
     }),


### PR DESCRIPTION
Fixes #117.

## Problem

Several sheet/app classes built their render context with **pure view-model logic** — grouping, sorting, container-hierarchy building, status derivation, dedup, scope resolution, label mapping — written inline inside the Foundry classes under `*/foundry/` and `src/apps/`. There it was excluded from coverage, sat outside the Foundry-free boundary guards (ESLint zone + purity test), and was prone to silent regressions.

## Fix

Move that pure shaping into co-located, Foundry-free `*-view` modules with unit tests; the sheets/apps keep only their Foundry-facing orchestration. No user-facing behavior change — context keys/shapes are unchanged, so templates render identically.

**Every sheet/app was evaluated.** The config-only ones (the other actor sheets + `SohlActorSheetBase`, all 16 item `_preparePropertiesContext` overrides) are intentionally left untouched. The five with real logic were refactored:

| Area | New module | Extracted |
|---|---|---|
| `BeingSheet` | `actor/logic/being-sheet-view.ts` | `groupBySubType` (replacing 5 inline copies), `buildContainerTree`, `buildStatusPills`, `buildBodyPartLozenges`, `clampHealthPct`, `splitWeaponsByRange`; also dropped the in-sheet `fvttEnrichHTML` proxy for a direct `TextEditor` call |
| `SohlItemSheetBase` | `item/logic/item-sheet-view.ts` | `localizeSubType`, `keyTransferredEffects`, `findSimilarItem` |
| `SohlActiveEffectSheet` | `effect/logic/effect-sheet-view.ts` | `buildChangeTypesMap`, `resolveEffectMetadataType`, `resolveEffectKeyChoices` |
| `DomainManagerApp`, `CalendarSettingsMenu` | `apps/logic/{domain-manager,calendar-settings}-view.ts` | `buildDomainGroups`, `buildCalendarViewModel`; registered `src/apps/logic/**` in the Foundry-free zones |

A convention note was added to `docs/concepts/architecture.md`: a sheet/app `FooSheet`/`FooApp` with pure view-model logic gets a `foo-sheet-view.ts` (apps: `foo-view.ts`) module in the sibling `logic/` dir, created only when there's real logic to hold (no empty placeholders). Canonical example: `being-sheet-view.ts`.

## Commits

Split per area for reviewability (plus one standalone `chore(prettier)` for three pre-existing unformatted files surfaced by `format:check`).

## Testing

- `npm run build` (types → 1288 tests → bundle) and `npm run docs` both pass.
- `npm run lint`, `npm run test:purity` (69 — the new modules are auto-imported there, proving they're Foundry-free), and `npm run format:check` all clean.
- **73 new unit tests** across the five `*-view` modules.
- Suggested manual smoke before merge: open a Being sheet, an item sheet, the Active Effect editor, and the Domain/Calendar settings apps — all should render unchanged.
