### PR TITLE
fix(release): upload release assets from build/dist

### DIFF
--- a/.changeset/fix-release-asset-path.md
+++ b/.changeset/fix-release-asset-path.md
@@ -1,0 +1,11 @@
+---
+"sohl": patch
+---
+
+**Fix the release workflow so GitHub Releases include the system archive**
+
+Fixes [#120](https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/issues/120):
+the release workflow uploaded its assets from `build/release/`, but the packaging
+step writes `system.zip` and `system.json` to `build/dist/`. The upload now points
+at `build/dist/`, so published Releases carry the installable system files that
+Foundry's manifest/download URLs reference.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,8 @@ jobs:
                   name: Release ${{ steps.decide.outputs.tag }}
                   body: ${{ steps.changelog.outputs.body }}
                   files: |
-                      build/release/system.zip
-                      build/release/system.json
+                      build/dist/system.zip
+                      build/dist/system.json
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes #120.

## Problem

The `Version and Release` workflow publishes a GitHub Release with **no assets** —
`system.zip` / `system.json` are not attached — so Foundry can't install or update
from the Release (its `manifest`/`download` URLs point at those files).

## Cause

The "Create GitHub Release" step uploaded from `build/release/`, but the packaging
step (`utils/pack-release.mjs`, run via `npm run build:pack-release`) writes the
release files to **`build/dist/`**. The upload path matched nothing.

## Fix

Point the upload at `build/dist/`:

```yaml
files: |
    build/dist/system.zip
    build/dist/system.json
```

One-line change in `.github/workflows/release.yml`, plus a `patch` changeset.
