### PR TITLE
chore(deploy): replace rsync with SFTP + intrinsic copy in push-stage

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,11 +6,36 @@
 #
 # Use absolute paths only. Shell variables ($HOME, ~) are NOT expanded.
 #
+# A *_DATA value may be a local path or a remote SFTP target. Local paths are
+# deployed with an intrinsic file copy; remote targets are deployed over SFTP.
+#
 # Local path example:
 #   FOUNDRYVTT_QA_DATA=/Users/yourname/Games/fvtt/data-dev
 #
-# Remote rsync path example (requires rsync and SSH access):
+# Remote SFTP target example ([user@]host:/path):
 #   FOUNDRYVTT_DEV_DATA=yourhost:/srv/docker/data/foundryvtt-dev
+#   FOUNDRYVTT_DEV_DATA=deploy@yourhost:/srv/docker/data/foundryvtt-dev
+#
+# SFTP authentication for remote targets (all optional, per stage DEV/QA/PROD).
+# Deploys use a pure-JS SSH client (no `ssh` binary required). By default the
+# running SSH agent is used, so if ssh already works without asking for a
+# passphrase, no extra config is needed.
+#
+# LINUX/UNIX/Mac
+# Supports the standard SSH Agent, which stores SSH keys securely. Detected
+# by the presence of the $SSH_AUTH_SOCK environment variable set by ssh-agent.
+#
+# WINDOWS
+# Supports both the OpenSSH named pipe (\\.\pipe\openssh-ssh-agent) and/or
+# the putty `pageant` protocols.
+#   FOUNDRYVTT_DEV_AGENT=pageant         # (optional) Per-phase agent override
+#   SOHL_SFTP_AGENT=pageant              # PuTTY Pageant, or a custom pipe/socket.
+#                                        # Set once to apply to all phases
+#
+#   FOUNDRYVTT_DEV_USER=deploy           # overrides the user@ prefix / $USER
+#   FOUNDRYVTT_DEV_PORT=22               # or set SOHL_SFTP_PORT for all stages
+#   FOUNDRYVTT_DEV_KEY=/path/to/id_ed25519   # key-file PATH; skips the agent
+#                                            # entirely (works with no agent at all)
 
 # Path to the Foundry VTT application install for each environment.
 FOUNDRYVTT_DEV=
@@ -23,7 +48,8 @@ FOUNDRYVTT_DEV_DATA=
 FOUNDRYVTT_QA_DATA=
 FOUNDRYVTT_PROD_DATA=
 
-# GitHub personal access token for creating releases via the GitHub API.
-# Required for "npm run deploy:release". Create a token at:
-# https://github.com/settings/tokens (needs "repo" scope)
-GITHUB_TOKEN=
+# GitHub access for the legacy local release helper (utils/release.mjs) uses
+# `gh auth login` — the gh CLI stores the token in your OS keychain and the
+# script reads it via `gh auth token`. No token belongs in this file. (If a
+# GITHUB_TOKEN is already exported in your environment, e.g. in CI, the script
+# honors it — but don't add one here.)

--- a/docs/how-to/build-and-deployment.md
+++ b/docs/how-to/build-and-deployment.md
@@ -6,14 +6,15 @@ script, how the build pipeline works, the layout of the `build/` directory,
 compendium packs and the Obsidian vault, deploying to a Foundry instance, and the
 release process. **Manual steps are called out explicitly** with a 🔧 marker.
 
-> Audience: maintainers and contributors working on the SoHL system itself. For the
-> rules of contributing, see [System Development](../contributing/system-development.md).
+> Audience: maintainers and contributors working on the SoHL system itself. For
+> the rules of contributing, see
+> [System Development](../contributing/system-development.md).
 
 ## 1. First-time setup
 
 🔧 **Prerequisites:** **Node.js ≥ 24** (see `engines` in `package.json`) and
-**Git** — that's all you need to build and test. Deploying to a Foundry instance may
-need extra access depending on the target (for example, SSH for a remote host).
+**Git** — that's all you need to build and test. Deploying to a Foundry instance
+may need extra access depending on the target (for example, SSH for a remote host).
 
 ```bash
 git clone https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT.git
@@ -25,8 +26,13 @@ npm run build                      # full build into build/stage/
 
 🔧 **`.env.local`** (gitignored — each developer keeps their own) holds the Foundry
 paths that drive deployment. You only need it when deploying to a Foundry instance;
-[§6 Deploying to a Foundry instance](#6-deploying-to-a-foundry-instance) lists every
-variable and what it's for.
+[§6 Deploying to a Foundry instance](#6-deploying-to-a-foundry-instance) lists
+every variable and what it's for.
+
+See the file **`.gitignore`** for the specifics of which files are local only
+and not stored in the repo. In particular, if you create a `nogit` folder,
+anything inside of it will be ignored. If you use VSCode or IntelliJ, those
+IDE configurations will also be ignored.
 
 ## 2. npm scripts
 
@@ -155,10 +161,11 @@ LevelDB format under `build/stage/packs/<pack>/`.
 
 ### Design decision — committed pack sources
 
-The pack content is _authored_ in the HeroicLands Obsidian vault, but **the build never reads
-the vault directly.** Instead, a separate `packs:export` step pulls everything out of
-the vault and writes it as plain JSON under `assets/packs/*/_source/`, and those JSON
-trees are **committed to this repository**.
+The pack content is _authored_ in the HeroicLands Obsidian vault, but **the build
+never reads the vault directly.** Instead, a separate `packs:export` step pulls
+everything out of the vault and writes it as plain JSON under
+`assets/packs/*/_source/`, and those JSON trees are **committed to this
+repository**.
 
 This is deliberate. It means the system builds from the repo alone — a contributor
 can run `npm run build` (or `npm run build:compiledb` for packs only) **without the
@@ -170,10 +177,10 @@ source of truth; the committed `_source/` JSON is the **build's** source of trut
 
 The authoritative content lives in the
 [HeroicLands Obsidian Vault](https://github.com/HeroicLands/HeroicLands), a sibling
-repository the pack scripts expect at **`../HeroicLands/`** (next to this repo — see
-`utils/packs/export.mjs`). Items, actors, and journal entries are authored there as
-Markdown files with YAML frontmatter (`package: sohl`, a `type:`, a stable `id:`,
-and folder/embedding metadata).
+repository the pack scripts expect at **`../HeroicLands/`** (next to this repo —
+see `utils/packs/export.mjs`). Items, actors, and journal entries are authored
+there as Markdown files with YAML frontmatter (`package: sohl`, a `type:`, a
+stable `id:`, and folder/embedding metadata).
 
 🔧 **Regenerating the pack sources from the vault** (maintainers with the vault):
 
@@ -186,9 +193,9 @@ npm run packs:rebuild
 ```
 
 `packs:export` (`utils/packs/export.mjs`) drives three per-pack compilers
-(`utils/packs/items.mjs`, `journals.mjs`, `actors.mjs`): they walk the vault, select
-files by frontmatter, validate folders against each pack's `folders.yaml`, and
-write per-entry JSON to the `_source/` tree.
+(`utils/packs/items.mjs`, `journals.mjs`, `actors.mjs`): they walk the vault,
+select files by frontmatter, validate folders against each pack's `folders.yaml`,
+and write per-entry JSON to the `_source/` tree.
 
 ## 6. Deploying to a Foundry instance
 
@@ -201,7 +208,24 @@ npm run push:qa        # copy build/stage/ only (no rebuild)
 
 The Foundry paths that drive deployment live in **`.env.local`** (copy it from
 `.env.local.example`). Use **absolute paths only** — `$HOME` and `~` are not
-expanded. A value may be a local path or a remote target (`host:/path`).
+expanded. A `*_DATA` value may be either:
+
+- a **local path** (e.g. `/Users/me/fvtt/data`) — deployed with an intrinsic
+  Node file copy, or
+- a **remote SFTP target** (`[user@]host:/path`) — deployed over SFTP via
+  `ssh2-sftp-client`, a pure-JS SSH client (no `ssh` binary required). By
+  default the running **SSH agent** is used — `$SSH_AUTH_SOCK` on macOS/Linux,
+  or the OpenSSH named pipe on Windows automatically — so if `ssh host` already
+  works no extra config is needed. No password or passphrase is read from
+  `.env.local` (for an encrypted key, load it into the agent with `ssh-add`).
+  Per-stage overrides exist for username, port, agent endpoint
+  (`..._AGENT=pageant` for PuTTY), and a key-file path that skips the agent
+  entirely — see the comments in `.env.local.example`.
+
+Either way the push is a **full mirror**: the destination
+`Data/systems/sohl/` is cleared and rewritten so it ends up an exact copy of
+`build/stage/` (stale files are removed). SFTP has no delta transfer, so a
+remote push re-uploads the whole staged build each time.
 
 | Variable                                               | Used for                                                                                                                                                                                            |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -209,7 +233,6 @@ expanded. A value may be a local path or a remote target (`host:/path`).
 | `FOUNDRYVTT_QA_DATA`                                   | The user-data root for **QA**, used by `npm run push:qa`.                                                                                                                                           |
 | `FOUNDRYVTT_PROD_DATA`                                 | The user-data root for **production**, used by `npm run push:prod`.                                                                                                                                 |
 | `FOUNDRYVTT_DEV` / `FOUNDRYVTT_QA` / `FOUNDRYVTT_PROD` | The Foundry **application install** path for each environment (recorded for convenience; the deploy step uses the `*_DATA` roots above).                                                            |
-| `GITHUB_TOKEN`                                         | A GitHub personal-access token with `repo` scope, for cutting a release via the GitHub API (`npm run deploy:release`). Releases are normally cut by CI, which supplies its own token.               |
 
 Point each `*_DATA` variable at the Foundry **user-data directory** (the one that
 contains `Data/`), not at `systems/` — the deploy appends the rest.
@@ -223,10 +246,10 @@ contains `Data/`), not at `systems/` — the deploy appends the rest.
 
 ## 7. Cutting a release
 
-**There is no `npm run release`.** A release is cut by **merging the auto-generated
-"Version Packages" PR**; the `Version and Release` GitHub Actions workflow
-(`.github/workflows/release.yml`) does the build, tag, GitHub Release, and asset
-upload. The only command you type by hand is the docs-deploy dispatch at the end.
+A release is cut by **merging the auto-generated "Version Packages" PR**; the
+`Version and Release` GitHub Actions workflow (`.github/workflows/release.yml`)
+does the build, tag, GitHub Release, and asset upload. The only command you
+type by hand is the docs-deploy dispatch at the end.
 
 ### While developing
 
@@ -242,19 +265,26 @@ These accumulate on `main` as PRs merge.
 
 ### To cut the release (maintainer)
 
-1. Make sure every change you want in the release is merged to `main`, each with its
-   changeset.
+1. Make sure every change you want in the release is merged to `main`, each
+   with its changeset.
 2. On each push to `main`, the workflow opens or updates a PR titled
    **`chore(release): version packages`** — it runs `changeset version` to bump
    `package.json` and rewrite `CHANGELOG.md`. Review it (the version and changelog
    are the release).
-3. 🔧 **Merge that PR.** Merging _is_ the release — there's nothing else to run
-   locally. The workflow re-runs on the merge, sees a new untagged version, and
-   automatically:
+3. 🔧 **Merge that PR** — in the GitHub UI, or from the CLI (the changesets
+   action opens it from the `changeset-release/main` branch):
+
+    ```bash
+    gh pr merge changeset-release/main [--admin] --squash --delete-branch
+    ```
+
+    Merging _is_ the release — there's nothing else to run locally. The workflow
+    re-runs on the merge, sees a new untagged version, and automatically:
     - runs `npm run build` then `npm run build:pack-release`,
     - creates the `v<version>` git tag and a **GitHub Release**,
     - attaches `system.zip` + `system.json` (the manifest/download Foundry installs
       and updates from).
+
 4. 🔧 **Publish the versioned API docs.** The Release is created with the Actions
    `GITHUB_TOKEN`, which by design can't trigger another workflow, so the docs
    workflow does **not** fire on its own. Run (substituting the version just
@@ -269,8 +299,8 @@ These accumulate on `main` as PRs merge.
 That's the entire release. Two notes:
 
 - `npm run deploy:release` only builds the release zip **locally** (into
-  `build/dist/`) for inspection — it does **not** publish anything. Releasing always
-  goes through the merge-the-PR flow above.
+  `build/dist/`) for inspection — it does **not** publish anything. Releasing
+  always goes through the merge-the-PR flow above.
 - A push to `main` with no pending changesets whose version is already tagged does
   nothing — ordinary merges never release.
 
@@ -287,30 +317,30 @@ That's the entire release. Two notes:
 
 ## 8. The build utility scripts
 
-The build/deploy/doc/pack tooling lives in **`utils/`** (with the pack tooling under
-`utils/packs/`). Each script carries a header comment describing its purpose and how
-to invoke it — read the file itself for the authoritative detail. In brief:
+The build/deploy/doc/pack tooling lives in **`utils/`** (with the pack tooling
+under `utils/packs/`). Each script carries a header comment describing its purpose
+and how to invoke it — read the file itself for the authoritative detail. In brief:
 
-| Script                              | Purpose                                                                            |
-| ----------------------------------- | ---------------------------------------------------------------------------------- |
-| `build-system-json.mjs`             | Generate `build/stage/system.json` from the template + version.                    |
-| `copy-assets.mjs`                   | Stage templates, lang, assets, and root files into `build/stage/`.                 |
-| `build-icon-font.mjs`               | Build the icon font from SVGs.                                                     |
-| `build-type-catalog.mjs`            | Generate `docs/reference/type-catalog.md` from the kind enums.                     |
-| `build-docs-entry.mjs`              | Generate the single TypeDoc entry barrel for cross-link resolution.                |
-| `sync-doc-version.mjs`              | Pin `…/latest` doc links to `…/v<version>` in generated output.                    |
-| `docs-coverage.mjs`                 | Report doc-comment coverage.                                                       |
-| `check-todos.mjs`                   | Fail the build on unlinked `TODO`/`FIXME` markers.                                 |
-| `clean.mjs`                         | Remove build output (`--distclean` for a deeper clean).                            |
-| `pack-release.mjs`                  | Zip `build/stage/` into the release `system.zip` + `system.json`.                  |
-| `push-stage.mjs`                    | deploy `build/stage/` to a Foundry instance (`dev`/`qa`/`prod`).                   |
-| `release.mjs`                       | Legacy local release path (CI normally cuts releases).                             |
-| `packs/build-compendiums.mjs`       | Compile/unpack `_source/` ↔ LevelDB packs (Foundry CLI).                           |
-| `packs/export.mjs`                  | Vault → `_source/` export orchestrator.                                            |
-| `packs/{items,journals,actors}.mjs` | Per-pack vault compilers.                                                          |
-| `packs/helpers.mjs`                 | Shared pack helpers (frontmatter, `_key`, folders).                                |
-| `packs/clean-sources.mjs`           | Remove generated `_source/` trees.                                                 |
-| `typedoc-plugin-*.mjs`              | TypeDoc plugins (source categories, nested nav, Foundry links, data-field schema). |
+| Script                              | Purpose                                                                                   |
+| ----------------------------------- | ----------------------------------------------------------------------------------------- |
+| `build-system-json.mjs`             | Generate `build/stage/system.json` from the template + version.                           |
+| `copy-assets.mjs`                   | Stage templates, lang, assets, and root files into `build/stage/`.                        |
+| `build-icon-font.mjs`               | Build the icon font from SVGs.                                                            |
+| `build-type-catalog.mjs`            | Generate `docs/reference/type-catalog.md` from the kind enums.                            |
+| `build-docs-entry.mjs`              | Generate the single TypeDoc entry barrel for cross-link resolution.                       |
+| `sync-doc-version.mjs`              | Pin `…/latest` doc links to `…/v<version>` in generated output.                           |
+| `docs-coverage.mjs`                 | Report doc-comment coverage.                                                              |
+| `check-todos.mjs`                   | Fail the build on unlinked `TODO`/`FIXME` markers.                                        |
+| `clean.mjs`                         | Remove build output (`--distclean` for a deeper clean).                                   |
+| `pack-release.mjs`                  | Zip `build/stage/` into the release `system.zip` + `system.json`.                         |
+| `push-stage.mjs`                    | deploy `build/stage/` to a Foundry instance (`dev`/`qa`/`prod`).                          |
+| `release.mjs`                       | Legacy local release path; authenticate with `gh auth login` (CI normally cuts releases). |
+| `packs/build-compendiums.mjs`       | Compile/unpack `_source/` ↔ LevelDB packs (Foundry CLI).                                  |
+| `packs/export.mjs`                  | Vault → `_source/` export orchestrator.                                                   |
+| `packs/{items,journals,actors}.mjs` | Per-pack vault compilers.                                                                 |
+| `packs/helpers.mjs`                 | Shared pack helpers (frontmatter, `_key`, folders).                                       |
+| `packs/clean-sources.mjs`           | Remove generated `_source/` trees.                                                        |
+| `typedoc-plugin-*.mjs`              | TypeDoc plugins (source categories, nested nav, Foundry links, data-field schema).        |
 
 ## See also
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sohl",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sohl",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "GPL-3.0-or-later AND CC-BY-SA-4.0",
             "dependencies": {
                 "jsep": "^1.4.0"
@@ -41,6 +41,7 @@
                 "npm-run-all": "^4.1.5",
                 "prettier": "^3.8.1",
                 "sass": "^1.69.0",
+                "ssh2-sftp-client": "^12.1.1",
                 "svg2ttf": "^6.1.0",
                 "svgicons2svgfont": "^16.0.0",
                 "svgo": "^4.0.1",
@@ -6428,6 +6429,16 @@
                 "node": ">=18.16.0"
             }
         },
+        "node_modules/buildcheck": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+            "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/cac": {
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -6978,6 +6989,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "dev": true,
+            "engines": [
+                "node >= 6.0"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/concat-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7037,6 +7079,21 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/cpu-features": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+            "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "buildcheck": "~0.0.6",
+                "nan": "^2.19.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/crc-32": {
@@ -14464,6 +14521,42 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/ssh2": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+            "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "asn1": "^0.2.6",
+                "bcrypt-pbkdf": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            },
+            "optionalDependencies": {
+                "cpu-features": "~0.0.10",
+                "nan": "^2.23.0"
+            }
+        },
+        "node_modules/ssh2-sftp-client": {
+            "version": "12.1.1",
+            "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-12.1.1.tgz",
+            "integrity": "sha512-wYVDgwkpcKG2iPGQQ+QR33xkWqLFIaVrYvA+uON4pmxTPaPuB81f1aooUEPN75e/9DCK6rrKYXb6zR6zP3+EtA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "concat-stream": "^2.0.0",
+                "ssh2": "^1.16.0"
+            },
+            "engines": {
+                "node": ">=18.20.4"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://square.link/u/4g7sPflL"
+            }
+        },
         "node_modules/sshpk": {
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -15513,6 +15606,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/typedoc": {
             "version": "0.27.6",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.8.1",
         "sass": "^1.69.0",
+        "ssh2-sftp-client": "^12.1.1",
         "svg2ttf": "^6.1.0",
         "svgicons2svgfont": "^16.0.0",
         "svgo": "^4.0.1",

--- a/utils/push-stage.mjs
+++ b/utils/push-stage.mjs
@@ -12,14 +12,30 @@
  */
 
 /**
- * Deploy the staged build to a Foundry data directory via rsync.
+ * Deploy the staged build to a Foundry data directory.
  *
  * Loads `.env.local` (then `.env`) from the repo root and reads the
- * destination from `FOUNDRYVTT_<STAGE>_DATA` (dev/qa/prod). rsyncs
- * `build/stage/` → `<dataRoot>/Data/systems/sohl/` with `--delete`,
- * supporting both local paths and remote `host:path` targets (the latter
- * requires rsync on PATH). Exits non-zero on a missing stage/env var or an
- * rsync failure.
+ * destination from `FOUNDRYVTT_<STAGE>_DATA` (dev/qa/prod). Mirrors
+ * `build/stage/` → `<dataRoot>/Data/systems/sohl/`, deleting stale files at
+ * the destination so it ends up an exact copy of the staged build.
+ *
+ * Two transports are chosen automatically from the destination value:
+ *   - **Local path** (e.g. `/Users/me/fvtt/data`) → intrinsic Node file copy.
+ *   - **Remote target** (`[user@]host:/path`) → SFTP over SSH.
+ *
+ * SFTP authentication (remote only), resolved per stage:
+ *   - username:  `user@` prefix, else `FOUNDRYVTT_<STAGE>_USER`, else $USER
+ *   - port:      `FOUNDRYVTT_<STAGE>_PORT` or `SOHL_SFTP_PORT`, else 22
+ *   - auth: the running SSH agent by default, cross-platform — `$SSH_AUTH_SOCK`
+ *       (macOS/Linux), else the Windows OpenSSH named pipe. Override the agent
+ *       endpoint with `FOUNDRYVTT_<STAGE>_AGENT` / `SOHL_SFTP_AGENT` (e.g.
+ *       "pageant" for PuTTY). Or set `FOUNDRYVTT_<STAGE>_KEY` to a private-key
+ *       file to skip the agent entirely (pure-JS, needs no `ssh` binary or
+ *       agent — the universal fallback; intended for unencrypted keys, since
+ *       no passphrase/password env vars are read — keep secrets out of
+ *       `.env.local`).
+ *
+ * Exits non-zero on a missing stage/env var or a deploy failure.
  *
  * Usage:
  *   npm run push:dev                       // → node utils/push-stage.mjs dev
@@ -30,9 +46,10 @@
 
 import path from "path";
 import process from "process";
-import { spawnSync } from "child_process";
+import fs from "fs/promises";
 import dotenv from "dotenv";
 import { fileURLToPath } from "url";
+import Client from "ssh2-sftp-client";
 
 const repoRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -42,7 +59,8 @@ const repoRoot = path.resolve(
 dotenv.config({ path: path.join(repoRoot, ".env.local") });
 dotenv.config({ path: path.join(repoRoot, ".env") });
 
-const SOURCE = "build/stage/";
+const SOURCE = path.join(repoRoot, "build", "stage");
+const SYSTEM_SUBPATH = ["Data", "systems", "sohl"];
 
 const STAGE_ENV_MAP = {
     dev: "FOUNDRYVTT_DEV_DATA",
@@ -51,13 +69,120 @@ const STAGE_ENV_MAP = {
 };
 
 function resolveStage(stageArg) {
-    const stage = String(stageArg || "")
+    return String(stageArg || "")
         .trim()
         .toLowerCase();
-    return stage;
 }
 
-function main() {
+/**
+ * Parse a `[user@]host:/path` remote target into its parts.
+ *
+ * @param {string} target
+ * @returns {{ username: string | undefined, host: string, remotePath: string }}
+ */
+function parseRemote(target) {
+    const colonIdx = target.indexOf(":");
+    const authority = target.slice(0, colonIdx);
+    const remotePath = target.slice(colonIdx + 1);
+    const atIdx = authority.indexOf("@");
+    const username = atIdx > 0 ? authority.slice(0, atIdx) : undefined;
+    const host = atIdx > 0 ? authority.slice(atIdx + 1) : authority;
+    return { username, host, remotePath };
+}
+
+/**
+ * Locate the SSH agent endpoint for agent-based auth, cross-platform.
+ *
+ * Precedence: an explicit `FOUNDRYVTT_<STAGE>_AGENT` / `SOHL_SFTP_AGENT`
+ * override (use "pageant" for PuTTY, or a named-pipe path), then
+ * `$SSH_AUTH_SOCK` (set by ssh-agent on macOS/Linux and by some Windows
+ * setups), then the Windows OpenSSH agent's default named pipe. Returns
+ * undefined when no agent is available (callers then rely on a key file).
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} stageUpper - uppercased stage name (e.g. "QA").
+ * @returns {string | undefined}
+ */
+function resolveAgent(env, stageUpper) {
+    return (
+        env[`FOUNDRYVTT_${stageUpper}_AGENT`] ||
+        env.SOHL_SFTP_AGENT ||
+        env.SSH_AUTH_SOCK ||
+        (process.platform === "win32" ?
+            "\\\\.\\pipe\\openssh-ssh-agent"
+        :   undefined)
+    );
+}
+
+/**
+ * Assemble an ssh2-sftp-client connection config for a stage.
+ *
+ * @param {string} stageUpper - uppercased stage name (e.g. "QA").
+ * @param {{ username: string | undefined, host: string }} remote
+ * @returns {Promise<object>}
+ */
+async function buildConnection(stageUpper, remote) {
+    const env = process.env;
+    const port = Number(
+        env[`FOUNDRYVTT_${stageUpper}_PORT`] ?? env.SOHL_SFTP_PORT ?? 22,
+    );
+    const username =
+        remote.username || env[`FOUNDRYVTT_${stageUpper}_USER`] || env.USER;
+
+    const conn = { host: remote.host, port, username };
+
+    // Default to the SSH agent so no secret is ever read from disk. An explicit
+    // key *path* (not a secret) is the escape hatch for agent-less setups.
+    const keyPath = env[`FOUNDRYVTT_${stageUpper}_KEY`];
+    if (keyPath) {
+        conn.privateKey = await fs.readFile(keyPath);
+    } else {
+        const agent = resolveAgent(env, stageUpper);
+        if (agent) conn.agent = agent;
+    }
+
+    return conn;
+}
+
+/**
+ * Mirror the staged build into a local directory, removing stale files.
+ *
+ * @param {string} srcAbs
+ * @param {string} destDir
+ */
+async function deployLocal(srcAbs, destDir) {
+    console.log(`Deploying ${srcAbs} → ${destDir} (local copy)`);
+    await fs.rm(destDir, { recursive: true, force: true });
+    await fs.mkdir(destDir, { recursive: true });
+    await fs.cp(srcAbs, destDir, { recursive: true });
+}
+
+/**
+ * Mirror the staged build into a remote directory over SFTP.
+ *
+ * @param {object} conn - ssh2-sftp-client connection config.
+ * @param {string} srcAbs
+ * @param {string} remoteDir
+ */
+async function deployRemote(conn, srcAbs, remoteDir) {
+    console.log(
+        `Deploying ${srcAbs} → ${conn.username}@${conn.host}:${remoteDir} (sftp)`,
+    );
+    const sftp = new Client();
+    sftp.on("upload", ({ source }) => console.log(`  ${source}`));
+    await sftp.connect(conn);
+    try {
+        if (await sftp.exists(remoteDir)) {
+            await sftp.rmdir(remoteDir, true);
+        }
+        await sftp.mkdir(remoteDir, true);
+        await sftp.uploadDir(srcAbs, remoteDir);
+    } finally {
+        await sftp.end();
+    }
+}
+
+async function main() {
     const stage = resolveStage(process.argv[2]);
     if (!stage) {
         console.error("Usage: node utils/push-stage.mjs <dev|qa|prod>");
@@ -82,35 +207,29 @@ function main() {
         process.exit(1);
     }
 
-    // Append the system path within the Foundry data directory.
-    // For remote rsync targets (host:path), insert after the colon.
+    // Remote targets look like `[user@]host:/path`; a leading "/" means local.
     const colonIdx = dataRoot.indexOf(":");
     const isRemote = colonIdx > 0 && !dataRoot.startsWith("/");
-    const destination =
-        isRemote ?
-            `${dataRoot.slice(0, colonIdx + 1)}${path.posix.join(dataRoot.slice(colonIdx + 1), "Data/systems/sohl/")}`
-        :   path.join(dataRoot, "Data", "systems", "sohl") + "/";
 
-    // Verify rsync is available for remote targets
-    if (isRemote) {
-        const check = spawnSync("rsync", ["--version"], { stdio: "ignore" });
-        if (check.error) {
-            console.error(
-                `Remote destination requires rsync, but it is not installed or not in PATH.`,
+    try {
+        if (isRemote) {
+            const remote = parseRemote(dataRoot);
+            const remoteDir = path.posix.join(
+                remote.remotePath,
+                ...SYSTEM_SUBPATH,
             );
-            process.exit(1);
+            const conn = await buildConnection(stage.toUpperCase(), remote);
+            await deployRemote(conn, SOURCE, remoteDir);
+        } else {
+            const destDir = path.join(dataRoot, ...SYSTEM_SUBPATH);
+            await deployLocal(SOURCE, destDir);
         }
-    }
-
-    const args = ["-avh", "--delete", SOURCE, destination];
-    const result = spawnSync("rsync", args, { stdio: "inherit" });
-
-    if (result.error) {
-        console.error(`Failed to run rsync: ${result.error.message}`);
+    } catch (err) {
+        console.error(`Deploy failed: ${err.message}`);
         process.exit(1);
     }
 
-    process.exit(result.status ?? 0);
+    console.log(`Deployed stage '${stage}' successfully.`);
 }
 
 main();

--- a/utils/release.mjs
+++ b/utils/release.mjs
@@ -18,20 +18,21 @@
  * release tagged `v<version>` on the `main` commit of
  * `HeroicLands/Song-of-Heroic-Lands-FoundryVTT` (the tag is created if
  * absent) and uploads `build/system-<version>.zip` (as `sohl-<version>.zip`)
- * and `system.json` as release assets. Requires `GITHUB_TOKEN` in
- * `.env.local`/`.env`/the environment, plus a prior `npm run build` and
- * `npm run build:pack-release`.
+ * and `system.json` as release assets. Needs a GitHub token — either
+ * `gh auth login` (preferred; keychain-backed) or `GITHUB_TOKEN` in the
+ * environment — plus a prior `npm run build` and `npm run build:pack-release`.
  *
  * NOTE: Legacy — CI normally cuts releases (see the release workflow); no
  * npm script wires this in. Kept for manual/local releases.
  *
  * Usage:
- *   node utils/release.mjs                 // GITHUB_TOKEN must be set
+ *   node utils/release.mjs                 // after `gh auth login`
  */
 
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { execFileSync } from "child_process";
 import { Octokit } from "@octokit/rest";
 import dotenv from "dotenv";
 
@@ -43,13 +44,36 @@ const repoRoot = path.resolve(
 dotenv.config({ path: path.join(repoRoot, ".env.local") });
 dotenv.config({ path: path.join(repoRoot, ".env") });
 
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+/**
+ * Resolve a GitHub token without requiring a PAT on disk.
+ *
+ * Prefers `GITHUB_TOKEN` from the environment (for CI / explicit overrides),
+ * then falls back to the `gh` CLI's keychain-backed token (`gh auth token`),
+ * so a local release works after `gh auth login` with no secret in
+ * `.env.local`.
+ *
+ * @returns {string | undefined}
+ */
+function resolveGithubToken() {
+    if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+    try {
+        const token = execFileSync("gh", ["auth", "token"], {
+            encoding: "utf8",
+        }).trim();
+        return token || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+const GITHUB_TOKEN = resolveGithubToken();
 const REPO_OWNER = "HeroicLands";
 const REPO_NAME = "Song-of-Heroic-Lands-FoundryVTT";
 
 if (!GITHUB_TOKEN) {
     console.error(
-        "GITHUB_TOKEN is not set. Add it to .env.local or set it in your environment.",
+        "No GitHub token available. Run 'gh auth login', or set GITHUB_TOKEN " +
+            "in your environment (avoid committing it to a file).",
     );
     process.exit(1);
 }


### PR DESCRIPTION
## What

Replaces the `rsync` dependency in `utils/push-stage.mjs` with two transports chosen automatically from the configured `FOUNDRYVTT_<STAGE>_DATA` value:

- **Local path** → intrinsic Node file copy (`fs.rm` + `fs.cp`), mirroring with stale-file deletion for `rsync --delete` parity.
- **Remote target** (`[user@]host:/path`) → SFTP over SSH via `ssh2-sftp-client` (pure JS, **no `ssh` binary required**), clearing the remote `systems/sohl/` dir before upload to mirror.

## Why

Drops the hard dependency on a local `rsync` binary and keeps deploy secrets off disk.

## Auth (secrets stay off disk)

- Defaults to the **SSH agent**, cross-platform: `$SSH_AUTH_SOCK` (macOS/Linux), the OpenSSH named pipe on Windows. Override with `FOUNDRYVTT_<STAGE>_AGENT` / `SOHL_SFTP_AGENT` (e.g. `pageant` for PuTTY).
- `FOUNDRYVTT_<STAGE>_KEY` points at a key-file **path** (not a secret) for agent-less setups. No password/passphrase env vars are read.
- Legacy release helper (`utils/release.mjs`) now resolves a token from `gh auth token` (OS keychain) when `GITHUB_TOKEN` is unset; the `GITHUB_TOKEN=` slot is removed from `.env.local.example`.

## Tradeoffs

- SFTP has no delta transfer — a remote push re-uploads the full staged build (~3 MB) each time. Fine for occasional QA/prod deploys.
- The remote dir is cleared before upload, so the system is briefly absent mid-push (matches existing stop/reload-Foundry guidance).

## Adds

`ssh2-sftp-client` devDependency. Docs updated in `build-and-deployment.md` §6 and `.env.local.example`.

## Verification

- Local push mirrors `build/stage/` into a scratch dir and removes a stray file (`--delete` parity).
- Invalid stage / connection failures caught cleanly, non-zero exit.
- `resolveAgent` precedence + Windows named-pipe default unit-checked.
- `release.mjs` passes the token guard via `gh auth token`, halts safely at the artifact guard.

> Note: base is `docs/contributing-onboarding` (not `main`) because the `build-and-deployment.md` file this edits only exists on that branch. Retarget to `main` once that branch lands.