### PR TITLE
chore: gitignore IDE and editor config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,28 @@
 CLAUDE.md
 AI.md
 
-# Visual Studio
+# IDE and editor config — per-user; never commit one contributor's editor setup
+# (project-wide policy like Prettier/ESLint config stays tracked; it's not IDE-specific)
+# VS Code (incl. recommended-extensions and settings)
 /.vscode/
 /*.code-workspace
+# JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.) and Fleet
+/.idea/
+/.fleet/
+# Zed
+/.zed/
+# Sublime Text (project + workspace)
+*.sublime-workspace
+*.sublime-project
+# Vim / Neovim
+*.swp
+*.swo
+Session.vim
+.netrwhist
+# Emacs (backups, auto-save, lock files)
+*~
+\#*\#
+.\#*
 
 # GitHub
 .github/copilot-instructions.md


### PR DESCRIPTION
## What

Ignore per-user IDE/editor config so no contributor's editor setup is ever committed to the repo. Covers the editors contributors are likely to use:

- **VS Code** — `/.vscode/` (incl. recommended-extensions and settings), `*.code-workspace`
- **JetBrains** (IntelliJ IDEA, WebStorm, …) + **Fleet** — `/.idea/`, `/.fleet/`
- **Zed** — `/.zed/`
- **Sublime Text** — `*.sublime-workspace`, `*.sublime-project`
- **Vim / Neovim** — `*.swp`, `*.swo`, `Session.vim`, `.netrwhist`
- **Emacs** — `*~`, `\#*\#`, `.\#*`

Also relabels the existing block, which was mislabeled `# Visual Studio` but actually lists VS Code (`.vscode/`); Visual Studio proper uses `.vs/`.

## Why

Editor config is personal — plugin sets, key bindings, theme, window layout. Committing one person's setup imposes it on everyone and creates churn. **Project-wide, editor-neutral policy (Prettier/ESLint config) stays tracked** — that's house style every editor obeys via `npm run format`, not an IDE choice.

## Notes

- Verified no currently-tracked file matches any new pattern (including the broad `*~`), so nothing is accidentally ignored.
- Intentionally **not** ignored: `.editorconfig` (none exists; if added later it's editor-neutral policy worth committing) and AI-editor dirs like `.cursor/` / `.windsurf/` (the repo's existing `# AI` section is where those would go if wanted).
