### PR TITLE
cleanup: keep unit tests within the logic-layer boundary (#125)

### DIFF
--- a/src/core/FoundryHelpers.ts
+++ b/src/core/FoundryHelpers.ts
@@ -328,6 +328,21 @@ export function fvttGetSetting(module: string, key: string): unknown {
 }
 
 /**
+ * Persist a game setting value.
+ * @param module - The module/system namespace the setting is registered under.
+ * @param key - The setting key.
+ * @param value - The value to store.
+ * @returns A promise resolving once the setting is written.
+ */
+export function fvttSetSetting(
+    module: string,
+    key: string,
+    value: unknown,
+): Promise<unknown> {
+    return (game as any).settings.set(module, key, value);
+}
+
+/**
  * Whether the current user is the active GM.
  * @returns `true` if the current user is the active GM.
  */

--- a/src/core/SohlDomains.ts
+++ b/src/core/SohlDomains.ts
@@ -12,6 +12,7 @@
  */
 
 import { DOMAIN_FAMILY, type DomainFamily } from "@src/utils/constants";
+import { fvttGetSetting, fvttSetSetting } from "@src/core/FoundryHelpers";
 
 const SETTING_MODULE = "sohl";
 const SETTING_KEY = "domains";
@@ -67,25 +68,12 @@ export interface DomainEntry {
 
 type DomainStore = Record<string, DomainEntry>;
 
-interface SettingsAPI {
-    get(module: string, key: string): unknown;
-    set(module: string, key: string, value: unknown): Promise<unknown>;
-}
-
-/**
- * The Foundry settings API used to read and write the domain store.
- * @returns The `game.settings` object typed as {@link SettingsAPI}.
- */
-function settings(): SettingsAPI {
-    return (game as any).settings as SettingsAPI;
-}
-
 /**
  * Read the stored domain registry, returning a defensive shallow copy.
  * @returns The current domain store, or an empty object if none is stored.
  */
 function readStore(): DomainStore {
-    const raw = settings().get(SETTING_MODULE, SETTING_KEY);
+    const raw = fvttGetSetting(SETTING_MODULE, SETTING_KEY);
     if (!raw || typeof raw !== "object") return {};
     // Defensive shallow copy so callers cannot mutate the stored object
     // through any reference they happen to hold onto.
@@ -97,7 +85,7 @@ function readStore(): DomainStore {
  * @param store - The domain store to write.
  */
 async function writeStore(store: DomainStore): Promise<void> {
-    await settings().set(SETTING_MODULE, SETTING_KEY, store);
+    await fvttSetSetting(SETTING_MODULE, SETTING_KEY, store);
 }
 
 /**

--- a/tests/core/SohlCalendar.test.ts
+++ b/tests/core/SohlCalendar.test.ts
@@ -5,8 +5,22 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+    describe,
+    it,
+    expect,
+    vi,
+    beforeAll,
+    afterAll,
+    afterEach,
+} from "vitest";
 import { SohlCalendarData } from "@src/core/SohlCalendar";
+// Mock-swapped shim (vitest alias); spy on it instead of touching raw Foundry globals.
+import * as FoundryHelpers from "@src/core/FoundryHelpers";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const SOHL_YEAR_DAYS = 360;
@@ -161,7 +175,7 @@ describe("SohlCalendarData", () => {
 
     describe("worldDate", () => {
         it("returns era-enriched components for the current world time", () => {
-            (globalThis as any).game.time.worldTime = 0;
+            vi.spyOn(FoundryHelpers, "fvttWorldTime").mockReturnValue(0);
             const cal = new SohlCalendarData(makeSohlConfig());
             const c = cal.worldDate;
             expect(c.year).toBe(0);
@@ -315,7 +329,7 @@ describe("SohlCalendarData", () => {
 
     describe("formatRelativeTime (static)", () => {
         function setWorldTime(t: number): void {
-            (globalThis as any).game.time.worldTime = t;
+            vi.spyOn(FoundryHelpers, "fvttWorldTime").mockReturnValue(t);
         }
 
         const origFormat = (globalThis as any).sohl.i18n.format;

--- a/tests/core/SohlDomains.test.ts
+++ b/tests/core/SohlDomains.test.ts
@@ -11,26 +11,28 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SohlDomains, type DomainEntry } from "@src/core/SohlDomains";
 import { DOMAIN_FAMILY } from "@src/utils/constants";
+// Mock-swapped shim (vitest alias); spy on it instead of touching raw Foundry globals.
+import * as FoundryHelpers from "@src/core/FoundryHelpers";
 
 /**
- * Backs game.settings with an in-memory store so SohlDomains can read/write
- * the "sohl.domains" setting under test. Foundry's real settings API is
- * stubbed in tests/setup.ts to return undefined; we override it per-test.
+ * Backs the settings shim with an in-memory store so SohlDomains can read/write
+ * the "sohl.domains" setting under test, by spying on the mock-swapped
+ * `fvttGetSetting`/`fvttSetSetting` rather than touching raw Foundry globals.
  */
 function installSettingsStore(): { reset: () => void } {
     const store = new Map<string, unknown>();
-    (globalThis as any).game.settings = {
-        get(_module: string, key: string): unknown {
-            return store.get(`${_module}.${key}`);
+    vi.spyOn(FoundryHelpers, "fvttGetSetting").mockImplementation(
+        (module: string, key: string) => store.get(`${module}.${key}`),
+    );
+    vi.spyOn(FoundryHelpers, "fvttSetSetting").mockImplementation(
+        async (module: string, key: string, value: unknown) => {
+            store.set(`${module}.${key}`, value);
+            return value;
         },
-        async set(_module: string, key: string, value: unknown): Promise<void> {
-            store.set(`${_module}.${key}`, value);
-        },
-        register() {},
-    };
+    );
     return {
         reset: () => store.clear(),
     };
@@ -60,6 +62,10 @@ describe("SohlDomains", () => {
         // explicitly.
         (globalThis as any).sohl.ready = false;
         store.reset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe("register", () => {

--- a/tests/core/SohlEventQueue.test.ts
+++ b/tests/core/SohlEventQueue.test.ts
@@ -16,13 +16,12 @@ import {
 } from "vitest";
 import { SohlEventQueue } from "@src/core/SohlEventQueue";
 import type { SohlTriggerContext } from "@src/core/SohlEventTrigger";
+// Mock-swapped shim (vitest alias); spy on it instead of touching raw Foundry globals.
+import * as FoundryHelpers from "@src/core/FoundryHelpers";
 
 function setUserFlags(opts: { isGM: boolean; isActiveGM: boolean }): void {
-    (globalThis as any).game.user = {
-        id: "testUser",
-        isGM: opts.isGM,
-        isActiveGM: opts.isActiveGM,
-    };
+    vi.spyOn(FoundryHelpers, "fvttIsCurrentUserGM").mockReturnValue(opts.isGM);
+    vi.spyOn(FoundryHelpers, "fvttIsActiveGM").mockReturnValue(opts.isActiveGM);
 }
 
 function worldTimeCtx(worldTime: number): SohlTriggerContext {
@@ -42,9 +41,7 @@ describe("SohlEventQueue", () => {
     });
 
     afterEach(() => {
-        warnSpy.mockRestore();
-        errorSpy.mockRestore();
-        setUserFlags({ isGM: true, isActiveGM: true });
+        vi.restoreAllMocks();
     });
 
     describe("subscribe / unsubscribe (GM gating)", () => {

--- a/tests/core/SohlHookBridge.test.ts
+++ b/tests/core/SohlHookBridge.test.ts
@@ -8,15 +8,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SohlEventQueue } from "@src/core/SohlEventQueue";
 import { wireSohlHookBridge } from "@src/core/SohlHookBridge";
+// Mock-swapped shim (vitest alias); spy on it instead of touching raw Foundry globals.
+import * as FoundryHelpers from "@src/core/FoundryHelpers";
 
 type HookFn = (...args: any[]) => any;
 
 function setUserFlags(opts: { isGM: boolean; isActiveGM: boolean }): void {
-    (globalThis as any).game.user = {
-        id: "testUser",
-        isGM: opts.isGM,
-        isActiveGM: opts.isActiveGM,
-    };
+    vi.spyOn(FoundryHelpers, "fvttIsCurrentUserGM").mockReturnValue(opts.isGM);
+    vi.spyOn(FoundryHelpers, "fvttIsActiveGM").mockReturnValue(opts.isActiveGM);
 }
 
 function captureHooks(): {
@@ -62,7 +61,7 @@ describe("SohlHookBridge", () => {
 
     afterEach(() => {
         captured.restore();
-        setUserFlags({ isGM: true, isActiveGM: true });
+        vi.restoreAllMocks();
     });
 
     it("registers all expected Foundry hooks", () => {

--- a/tests/guards/no-foundry-globals.test.ts
+++ b/tests/guards/no-foundry-globals.test.ts
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Song of Heroic Lands (SoHL) system for Foundry VTT.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.com>
+ *
+ * This work is licensed under the GNU General Public License v3.0 (GPLv3).
+ * You may copy, modify, and distribute it under the terms of that license.
+ *
+ * For full terms, see the LICENSE.md file in the project root or visit:
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Boundary guard (issue #125): unit tests are scoped to the logic layer and must
+ * reach Foundry only through the mock-swapped `FoundryHelpers` shim — never by
+ * poking `globalThis.game`. Foundry-global setup belongs solely in
+ * `tests/setup.ts` and `tests/mocks/`.
+ *
+ * When a test needs to drive Foundry-dependent behavior, spy the `fvtt*` shim
+ * the source actually calls — e.g.
+ * `vi.spyOn(FoundryHelpers, "fvttCurrentUser").mockReturnValue({ isGM: true })`
+ * — rather than mutating the raw global.
+ */
+import { describe, it, expect } from "vitest";
+import { globSync } from "glob";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const testsRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+);
+
+// Matches `globalThis.game` and `(globalThis as any).game` member access.
+const FORBIDDEN = /\bglobalThis\b[^\n]*?\.\s*game\b/;
+
+const files = globSync("**/*.test.ts", {
+    cwd: testsRoot,
+    absolute: true,
+}).filter(
+    (f) =>
+        !f.includes(`${path.sep}mocks${path.sep}`) &&
+        !f.endsWith("no-foundry-globals.test.ts"),
+);
+
+describe("unit tests stay within the logic-layer boundary (issue #125)", () => {
+    it.each(files)("%s does not reach globalThis.game", (file) => {
+        const offenders = readFileSync(file, "utf8")
+            .split("\n")
+            .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+            .filter(({ line }) => FORBIDDEN.test(line));
+        expect(
+            offenders,
+            `${path.relative(testsRoot, file)} reaches globalThis.game directly. ` +
+                `Spy the FoundryHelpers shim the source calls instead:\n` +
+                offenders.map((o) => `  L${o.n}: ${o.line}`).join("\n"),
+        ).toEqual([]);
+    });
+});

--- a/tests/item/Action.test.ts
+++ b/tests/item/Action.test.ts
@@ -6,6 +6,9 @@ import {
 } from "@src/domain/action/SohlAction";
 import { ACTION_SUBTYPE } from "@src/utils/constants";
 import * as ContextMenuEntryModule from "@src/utils/ContextMenuEntry";
+// Resolves to the mock-swapped shim in tests (vitest.config.ts alias); spy on
+// it instead of poking raw Foundry globals.
+import * as FoundryHelpers from "@src/core/FoundryHelpers";
 
 /** Foundry `CONST.DOCUMENT_OWNERSHIP_LEVELS` mirror for test readability. */
 const OWNERSHIP = { NONE: 0, LIMITED: 1, OBSERVER: 2, OWNER: 3 } as const;
@@ -114,19 +117,21 @@ describe("SohlAction.visible", () => {
     });
 
     it("exposes isGM, true when the current user is a GM", () => {
-        const prev = (globalThis as any).game.user.isGM;
-        (globalThis as any).game.user.isGM = true;
+        const userSpy = vi
+            .spyOn(FoundryHelpers, "fvttCurrentUser")
+            .mockReturnValue({ isGM: true } as any);
         const action = makeAction({ visible: "isGM" });
         expect(action.visible(mockElement())).toBe(true);
-        (globalThis as any).game.user.isGM = prev;
+        userSpy.mockRestore();
     });
 
     it("exposes isGM, false when the current user is not a GM", () => {
-        const prev = (globalThis as any).game.user.isGM;
-        (globalThis as any).game.user.isGM = false;
+        const userSpy = vi
+            .spyOn(FoundryHelpers, "fvttCurrentUser")
+            .mockReturnValue({ isGM: false } as any);
         const action = makeAction({ visible: "isGM" });
         expect(action.visible(mockElement())).toBe(false);
-        (globalThis as any).game.user.isGM = prev;
+        userSpy.mockRestore();
     });
 
     it("returns false (hidden) on compile error and warns", () => {
@@ -381,16 +386,18 @@ describe("userMeetsExecutePermission", () => {
     });
 
     it("passes the configured minActorOwnership to testUserPermission", () => {
+        const user = { isGM: false } as any;
+        const userSpy = vi
+            .spyOn(FoundryHelpers, "fvttCurrentUser")
+            .mockReturnValue(user);
         const spy = vi.fn().mockReturnValue(true);
         const actor = { testUserPermission: spy } as any;
         userMeetsExecutePermission(
             makeActionData({ minActorOwnership: OWNERSHIP.OBSERVER }),
             actor,
         );
-        expect(spy).toHaveBeenCalledWith(
-            (globalThis as any).game.user,
-            OWNERSHIP.OBSERVER,
-        );
+        expect(spy).toHaveBeenCalledWith(user, OWNERSHIP.OBSERVER);
+        userSpy.mockRestore();
     });
 
     it("defaults to OWNER when minActorOwnership is missing", () => {

--- a/tests/mocks/foundry/core/FoundryHelpers.ts
+++ b/tests/mocks/foundry/core/FoundryHelpers.ts
@@ -120,6 +120,14 @@ export function fvttGetSetting(_module: string, _key: string): unknown {
     return undefined;
 }
 
+export async function fvttSetSetting(
+    _module: string,
+    _key: string,
+    _value: unknown,
+): Promise<unknown> {
+    return undefined;
+}
+
 export function fvttIsActiveGM(): boolean {
     return !!(globalThis as any).game?.user?.isActiveGM;
 }


### PR DESCRIPTION
Unit tests reached `globalThis.game.*` to drive behavior, exercising raw Foundry globals instead of the FoundryHelpers shim the source actually uses. Spy the shim seam instead, and add a guard so it can't regress.

- Action / Calendar / EventQueue / HookBridge tests: replace globalThis.game pokes with vi.spyOn on the shim the source calls — fvttCurrentUser, fvttWorldTime, fvttIsCurrentUserGM, fvttIsActiveGM.
- SohlDomains read/wrote settings through a local `(game as any).settings` bridge — the one real source-side Foundry access. Route it through the shim instead: add fvttSetSetting to FoundryHelpers (+ mock), drop the local bridge, and use fvttGetSetting/fvttSetSetting. The Domains test now spies those.
- HookBridge still captures globalThis.Hooks: it is the one module permitted to call Hooks.on directly (no registration shim exists), so that is Foundry-layer wiring, left as-is and out of this guard's scope.
- New guard tests/guards/no-foundry-globals.test.ts fails the suite if any test (outside tests/mocks/ and tests/setup.ts) reaches globalThis.game.

All suites green (1372 pass), build:types/lint/test:purity clean.

Closes #125